### PR TITLE
commit_iterated(): return committed slots

### DIFF
--- a/benches/iterators.rs
+++ b/benches/iterators.rs
@@ -12,7 +12,7 @@ pub fn iterators(criterion: &mut criterion::Criterion) {
                 for elem in &mut chunk {
                     assert_eq!(*elem, black_box(i));
                 }
-                chunk.commit_iterated()
+                chunk.commit_iterated();
             } else {
                 unreachable!();
             }


### PR DESCRIPTION
This can be helpful information to callers, but it can also be simply ignored.