### PR TITLE
DOC: Don't rely on wrap-around behavior in "drop" example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -836,9 +836,7 @@ impl<T> Consumer<T> {
     ///     assert!(p.push(Thing).is_ok()); // 3
     ///
     ///     if let Ok(chunk) = c.read_chunk(2) {
-    ///         let (first, second) = chunk.as_slices();
-    ///         assert_eq!(first.len(), 1);
-    ///         assert_eq!(second.len(), 1);
+    ///         assert_eq!(chunk.len(), 2);
     ///         assert_eq!(unsafe { DROP_COUNT }, 1);
     ///         chunk.commit(1); // Drops only one of the two Things
     ///         assert_eq!(unsafe { DROP_COUNT }, 2);


### PR DESCRIPTION
I consider the wrap-around behavior an implementation detail (except when using `RingBuffer::with_chunks()`), therefore the code should not rely on the lengths of the individual slices.