### PR TITLE
Use .cast() instead of "as *mut _"

### DIFF
--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -467,8 +467,8 @@ impl<T> WriteChunkUninit<'_, T> {
     pub fn as_mut_slices(&mut self) -> (&mut [MaybeUninit<T>], &mut [MaybeUninit<T>]) {
         unsafe {
             (
-                core::slice::from_raw_parts_mut(self.first_ptr as *mut _, self.first_len),
-                core::slice::from_raw_parts_mut(self.second_ptr as *mut _, self.second_len),
+                core::slice::from_raw_parts_mut(self.first_ptr.cast(), self.first_len),
+                core::slice::from_raw_parts_mut(self.second_ptr.cast(), self.second_len),
             )
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -723,7 +723,7 @@ impl<T: Copy> CopyToUninit<T> for [T] {
             dst.len(),
             "source slice length does not match destination slice length"
         );
-        let dst_ptr = dst.as_mut_ptr() as *mut _;
+        let dst_ptr = dst.as_mut_ptr().cast();
         unsafe {
             self.as_ptr().copy_to_nonoverlapping(dst_ptr, self.len());
             core::slice::from_raw_parts_mut(dst_ptr, self.len())


### PR DESCRIPTION
I'm not sure whether that's considered to be better, any opinions?