### PR TITLE
Initial no_std support (with alloc)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ exclude = [
     ".*",
 ]
 
+[features]
+std = []
+default = ["std"]
+
 [dependencies]
 cache-padded = "1.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,9 +195,9 @@
 #![warn(rust_2018_idioms)]
 #![deny(missing_docs)]
 
-#![cfg_attr(not(feature="std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature="std"))]
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 use core::cell::Cell;
@@ -208,14 +208,14 @@ use core::ptr;
 use core::slice;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 use std::sync::Arc;
-#[cfg(not(feature="std"))]
+#[cfg(not(feature = "std"))]
 use alloc::sync::Arc;
 
-#[cfg(not(feature="std"))]
+#[cfg(not(feature = "std"))]
 use alloc::format;
-#[cfg(not(feature="std"))]
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use cache_padded::CachePadded;
@@ -1332,7 +1332,7 @@ impl<'a, T> Iterator for ReadChunk<'a, T> {
     }
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 impl std::io::Write for Producer<u8> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
@@ -1361,7 +1361,7 @@ impl std::io::Write for Producer<u8> {
     }
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 impl std::io::Read for Consumer<u8> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
@@ -1389,7 +1389,7 @@ pub enum PopError {
     Empty,
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 impl std::error::Error for PopError {}
 
 impl fmt::Display for PopError {
@@ -1407,7 +1407,7 @@ pub enum PeekError {
     Empty,
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 impl std::error::Error for PeekError {}
 
 impl fmt::Display for PeekError {
@@ -1425,7 +1425,7 @@ pub enum PushError<T> {
     Full(T),
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 impl<T> std::error::Error for PushError<T> {}
 
 impl<T> fmt::Debug for PushError<T> {
@@ -1454,7 +1454,7 @@ pub enum ChunkError {
     TooFewSlots(usize),
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 impl std::error::Error for ChunkError {}
 
 impl fmt::Display for ChunkError {

--- a/tests/write_and_read.rs
+++ b/tests/write_and_read.rs
@@ -1,3 +1,5 @@
+#![cfg(feature="std")]
+
 use std::io::{Read, Write};
 
 use rtrb::RingBuffer;


### PR DESCRIPTION
I hadn't even realised someone else was looking for this, I just like making crates no_std, but it should resolve #35.

Note that I've only done the code part. Someone should probably add running the tests under no-std and maybe the no-std category and things like that.