### PR TITLE
Support for fixed-size chunks

### DIFF
--- a/benches/single_thread_single_byte.rs
+++ b/benches/single_thread_single_byte.rs
@@ -36,7 +36,7 @@ pub fn criterion_benchmark(criterion: &mut criterion::Criterion) {
         v.pop().unwrap()
     });
 
-    let (mut p, mut c) = RingBuffer::<u8>::new(1).split();
+    let (mut p, mut c) = RingBuffer::new(1);
 
     add_function(&mut group, "1-push-pop", |i| {
         p.push(i).unwrap();

--- a/benches/single_thread_two_bytes.rs
+++ b/benches/single_thread_two_bytes.rs
@@ -41,7 +41,7 @@ pub fn criterion_benchmark(criterion: &mut criterion::Criterion) {
     group.throughput(criterion::Throughput::Bytes(2));
     group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
 
-    let (mut p, mut c) = RingBuffer::<u8>::new(3).split();
+    let (mut p, mut c) = RingBuffer::new(3);
 
     add_function(&mut group, "1-push-pop", |data| {
         let mut result = [0; 2];

--- a/benches/two_threads.rs
+++ b/benches/two_threads.rs
@@ -91,7 +91,7 @@ fn criterion_benchmark(criterion: &mut criterion::Criterion) {
     add_function(
         &mut group,
         "",
-        |capacity| RingBuffer::new(capacity).split(),
+        RingBuffer::new,
         |p, i| p.push(i).is_ok(),
         |c| c.pop().ok(),
     );

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -1,0 +1,778 @@
+//! Writing and reading chunks of data into and from a [`RingBuffer`].
+//!
+//! Multiple items can be written at once by using [`Producer::write_chunk()`]
+//! or its `unsafe` (but probably slightly faster) cousin [`Producer::write_chunk_uninit()`].
+//!
+//! Multiple items can be read at once with [`Consumer::read_chunk()`].
+//!
+//! # Examples
+//!
+//! Producing and consuming multiple items at once with
+//! [`Producer::write_chunk()`] and [`Consumer::read_chunk()`], respectively.
+//! This example uses a single thread for simplicity, but in a real application,
+//! `producer` and `consumer` would of course live on different threads:
+//!
+//! ```
+//! use rtrb::RingBuffer;
+//!
+//! let (mut producer, mut consumer) = RingBuffer::new(5).split();
+//!
+//! if let Ok(mut chunk) = producer.write_chunk(4) {
+//!     // NB: Don't use `chunk` as the first iterator in zip() if the other one might be shorter!
+//!     for (src, dst) in vec![10, 11, 12].into_iter().zip(&mut chunk) {
+//!         *dst = src;
+//!     }
+//!     // Don't forget to make the written slots available for reading!
+//!     chunk.commit_iterated();
+//!     // Note that we requested 4 slots but we've only written 3!
+//! } else {
+//!     unreachable!();
+//! }
+//!
+//! assert_eq!(producer.slots(), 2);
+//! assert_eq!(consumer.slots(), 3);
+//!
+//! if let Ok(mut chunk) = consumer.read_chunk(2) {
+//!     // NB: Even though we are just reading, `chunk` needs to be mutable for iteration!
+//!     assert_eq!((&mut chunk).collect::<Vec<_>>(), [&10, &11]);
+//!     chunk.commit_iterated(); // Mark the slots as "consumed"
+//!     // chunk.commit_all() would also work here.
+//! } else {
+//!     unreachable!();
+//! }
+//!
+//! // One element is still in the queue:
+//! assert_eq!(consumer.peek(), Ok(&12));
+//!
+//! let data = vec![20, 21, 22, 23];
+//! if let Ok(mut chunk) = producer.write_chunk(4) {
+//!     let (first, second) = chunk.as_mut_slices();
+//!     let mid = first.len();
+//!     first.copy_from_slice(&data[..mid]);
+//!     second.copy_from_slice(&data[mid..]);
+//!     chunk.commit_all();
+//! } else {
+//!     unreachable!();
+//! }
+//!
+//! assert!(producer.is_full());
+//! assert_eq!(consumer.slots(), 5);
+//!
+//! let mut v = Vec::<i32>::with_capacity(5);
+//! if let Ok(chunk) = consumer.read_chunk(5) {
+//!     let (first, second) = chunk.as_slices();
+//!     v.extend(first);
+//!     v.extend(second);
+//!     chunk.commit_all();
+//! } else {
+//!     unreachable!();
+//! }
+//! assert_eq!(v, [12, 20, 21, 22, 23]);
+//! assert!(consumer.is_empty());
+//! ```
+//!
+//! ## Common Access Patterns
+//!
+//! The following examples show the [`Producer`] side;
+//! similar patterns can of course be used with [`Consumer::read_chunk()`] as well.
+//! Furthermore, the examples use [`Producer::write_chunk()`],
+//! which requires the trait bounds `T: Copy + Default`.
+//! If that's too restrictive or if you want to squeeze out the last bit of performance,
+//! you can use [`Producer::write_chunk_uninit()`] instead,
+//! but this will force you to write some `unsafe` code.
+//!
+//! Copy a whole slice of items into the ring buffer, but only if space permits
+//! (if not, the input slice is returned as an error):
+//!
+//! ```
+//! use rtrb::Producer;
+//!
+//! fn push_entire_slice<'a, T>(queue: &mut Producer<T>, slice: &'a [T]) -> Result<(), &'a [T]>
+//! where
+//!     T: Copy + Default,
+//! {
+//!     if let Ok(mut chunk) = queue.write_chunk(slice.len()) {
+//!         let (first, second) = chunk.as_mut_slices();
+//!         let mid = first.len();
+//!         first.copy_from_slice(&slice[..mid]);
+//!         second.copy_from_slice(&slice[mid..]);
+//!         chunk.commit_all();
+//!         Ok(())
+//!     } else {
+//!         Err(slice)
+//!     }
+//! }
+//! ```
+//!
+//! Copy as many items as possible from a given slice, returning the remainder of the slice
+//! (which will be empty if there was space for all items):
+//!
+//! ```
+//! use rtrb::{Producer, chunks::ChunkError::TooFewSlots};
+//!
+//! fn push_partial_slice<'a, T>(queue: &mut Producer<T>, slice: &'a [T]) -> &'a [T]
+//! where
+//!     T: Copy + Default,
+//! {
+//!     let mut chunk = match queue.write_chunk(slice.len()) {
+//!         Ok(chunk) => chunk,
+//!         // This is an optional optimization if the queue tends to be full:
+//!         Err(TooFewSlots(0)) => return slice,
+//!         // Remaining slots are returned, this will always succeed:
+//!         Err(TooFewSlots(n)) => queue.write_chunk(n).unwrap(),
+//!     };
+//!     let end = chunk.len();
+//!     let (first, second) = chunk.as_mut_slices();
+//!     let mid = first.len();
+//!     first.copy_from_slice(&slice[..mid]);
+//!     second.copy_from_slice(&slice[mid..end]);
+//!     chunk.commit_all();
+//!     &slice[end..]
+//! }
+//! ```
+//!
+//! Write as many slots as possible, given an iterator
+//! (and return the number of written slots):
+//!
+//! ```
+//! use rtrb::{Producer, chunks::ChunkError::TooFewSlots};
+//!
+//! fn push_from_iter<T, I>(queue: &mut Producer<T>, iter: &mut I) -> usize
+//! where
+//!     T: Copy + Default,
+//!     I: Iterator<Item = T>,
+//! {
+//!     let n = match iter.size_hint() {
+//!         (_, None) => queue.slots(),
+//!         (_, Some(n)) => n,
+//!     };
+//!     let mut chunk = match queue.write_chunk(n) {
+//!         Ok(chunk) => chunk,
+//!         // As above, this is an optional optimization:
+//!         Err(TooFewSlots(0)) => return 0,
+//!         // As above, this will always succeed:
+//!         Err(TooFewSlots(n)) => queue.write_chunk(n).unwrap(),
+//!     };
+//!     for (source, target) in iter.zip(&mut chunk) {
+//!         *target = source;
+//!     }
+//!     chunk.commit_iterated()
+//! }
+//! ```
+
+use core::fmt;
+use core::mem::MaybeUninit;
+use core::sync::atomic::Ordering;
+
+use crate::{Consumer, CopyToUninit, Producer, RingBuffer};
+
+impl<T> RingBuffer<T> {
+    /// Creates a `RingBuffer` with a capacity of `chunks * chunk_size`.
+    ///
+    /// On top of multiplying the two numbers for us,
+    /// this also guarantees that the ring buffer wrap-around happens
+    /// at an integer multiple of `chunk_size`.
+    /// This means that if [`Consumer::read_chunk()`] is used *exclusively* with
+    /// `chunk_size` (and [`Consumer::pop()`] is *not* used in-between),
+    /// the first slice returned from [`ReadChunk::as_slices()`]
+    /// will always contain the entire chunk and the second slice will always be empty.
+    /// Same for [`Producer::write_chunk()`]/[`WriteChunk::as_mut_slices()`] and
+    /// [`Producer::write_chunk_uninit()`]/[`WriteChunkUninit::as_mut_slices()`]
+    /// (as long as [`Producer::push()`] is *not* used in-between).
+    ///
+    /// If above conditions have been violated, the wrap-around guarantee can be restored
+    /// wit [`reset()`](RingBuffer::reset).
+    pub fn with_chunks(chunks: usize, chunk_size: usize) -> RingBuffer<T> {
+        // NB: Currently, there is nothing special to do here, but in the future
+        //     it might be necessary to take some steps to guarantee the promised behavior.
+        Self::new(chunks * chunk_size)
+    }
+}
+
+impl<T> Producer<T> {
+    /// Returns `n` slots (initially containing their [`Default`] value) for writing.
+    ///
+    /// If not enough slots are available, an error
+    /// (containing the number of available slots) is returned.
+    ///
+    /// The elements can be accessed with [`WriteChunk::as_mut_slices()`] or
+    /// by iterating over (a `&mut` to) the [`WriteChunk`].
+    ///
+    /// The provided slots are *not* automatically made available
+    /// to be read by the [`Consumer`].
+    /// This has to be explicitly done by calling [`WriteChunk::commit()`],
+    /// [`WriteChunk::commit_iterated()`] or [`WriteChunk::commit_all()`].
+    ///
+    /// The type parameter `T` has a trait bound of [`Copy`],
+    /// which makes sure that no destructors are called at any time
+    /// (because it implies [`!Drop`](Drop)).
+    ///
+    /// For an unsafe alternative that has no restrictions on `T`,
+    /// see [`Producer::write_chunk_uninit()`].
+    ///
+    /// # Examples
+    ///
+    /// See the [module-level documentation](crate::chunks#examples) for examples.
+    pub fn write_chunk(&mut self, n: usize) -> Result<WriteChunk<'_, T>, ChunkError>
+    where
+        T: Copy + Default,
+    {
+        self.write_chunk_uninit(n).map(WriteChunk::from)
+    }
+
+    /// Returns `n` (uninitialized) slots for writing.
+    ///
+    /// If not enough slots are available, an error
+    /// (containing the number of available slots) is returned.
+    ///
+    /// The elements can be accessed with [`WriteChunkUninit::as_mut_slices()`] or
+    /// by iterating over (a `&mut` to) the [`WriteChunkUninit`].
+    ///
+    /// The provided slots are *not* automatically made available
+    /// to be read by the [`Consumer`].
+    /// This has to be explicitly done by calling [`WriteChunkUninit::commit()`],
+    /// [`WriteChunkUninit::commit_iterated()`] or
+    /// [`WriteChunkUninit::commit_all()`].
+    ///
+    /// # Safety
+    ///
+    /// This function itself is safe, but accessing the returned slots might not be,
+    /// as well as invoking some methods of [`WriteChunkUninit`].
+    ///
+    /// For a safe alternative that provides [`Default`]-initialized slots,
+    /// see [`Producer::write_chunk()`].
+    pub fn write_chunk_uninit(&mut self, n: usize) -> Result<WriteChunkUninit<'_, T>, ChunkError> {
+        let tail = self.tail.get();
+
+        // Check if the queue has *possibly* not enough slots.
+        if self.buffer.capacity - self.buffer.distance(self.head.get(), tail) < n {
+            // Refresh the head ...
+            let head = self.buffer.head.load(Ordering::Acquire);
+            self.head.set(head);
+
+            // ... and check if there *really* are not enough slots.
+            let slots = self.buffer.capacity - self.buffer.distance(head, tail);
+            if slots < n {
+                return Err(ChunkError::TooFewSlots(slots));
+            }
+        }
+        let tail = self.buffer.collapse_position(tail);
+        let first_len = n.min(self.buffer.capacity - tail);
+        Ok(WriteChunkUninit {
+            first_ptr: unsafe { self.buffer.data_ptr.add(tail) },
+            first_len,
+            second_ptr: self.buffer.data_ptr,
+            second_len: n - first_len,
+            producer: self,
+            iterated: 0,
+        })
+    }
+}
+
+impl<T> Consumer<T> {
+    /// Returns `n` slots for reading.
+    ///
+    /// If not enough slots are available, an error
+    /// (containing the number of available slots) is returned.
+    ///
+    /// The elements can be accessed with [`ReadChunk::as_slices()`] or
+    /// by iterating over (a `&mut` to) the [`ReadChunk`].
+    ///
+    /// The provided slots are *not* automatically made available
+    /// to be written again by the [`Producer`].
+    /// This has to be explicitly done by calling [`ReadChunk::commit()`],
+    /// [`ReadChunk::commit_iterated()`] or [`ReadChunk::commit_all()`].
+    /// You can "peek" at the contained values by simply
+    /// not calling any of the "commit" methods.
+    ///
+    /// # Examples
+    ///
+    /// Items are dropped when [`ReadChunk::commit()`], [`ReadChunk::commit_iterated()`]
+    /// or [`ReadChunk::commit_all()`] is called
+    /// (which is only relevant if `T` implements [`Drop`]).
+    ///
+    /// ```
+    /// use rtrb::RingBuffer;
+    ///
+    /// // Static variable to count all drop() invocations
+    /// static mut DROP_COUNT: i32 = 0;
+    /// #[derive(Debug)]
+    /// struct Thing;
+    /// impl Drop for Thing {
+    ///     fn drop(&mut self) { unsafe { DROP_COUNT += 1; } }
+    /// }
+    ///
+    /// // Scope to limit lifetime of ring buffer
+    /// {
+    ///     let (mut p, mut c) = RingBuffer::new(2).split();
+    ///
+    ///     assert!(p.push(Thing).is_ok()); // 1
+    ///     assert!(p.push(Thing).is_ok()); // 2
+    ///     if let Ok(thing) = c.pop() {
+    ///         // "thing" has been *moved* out of the queue but not yet dropped
+    ///         assert_eq!(unsafe { DROP_COUNT }, 0);
+    ///     } else {
+    ///         unreachable!();
+    ///     }
+    ///     // First Thing has been dropped when "thing" went out of scope:
+    ///     assert_eq!(unsafe { DROP_COUNT }, 1);
+    ///     assert!(p.push(Thing).is_ok()); // 3
+    ///
+    ///     if let Ok(chunk) = c.read_chunk(2) {
+    ///         assert_eq!(chunk.len(), 2);
+    ///         assert_eq!(unsafe { DROP_COUNT }, 1);
+    ///         chunk.commit(1); // Drops only one of the two Things
+    ///         assert_eq!(unsafe { DROP_COUNT }, 2);
+    ///     } else {
+    ///         unreachable!();
+    ///     }
+    ///     // The last Thing is still in the queue ...
+    ///     assert_eq!(unsafe { DROP_COUNT }, 2);
+    /// }
+    /// // ... and it is dropped when the ring buffer goes out of scope:
+    /// assert_eq!(unsafe { DROP_COUNT }, 3);
+    /// ```
+    ///
+    /// See the [module-level documentation](crate::chunks#examples) for more examples.
+    pub fn read_chunk(&mut self, n: usize) -> Result<ReadChunk<'_, T>, ChunkError> {
+        let head = self.head.get();
+
+        // Check if the queue has *possibly* not enough slots.
+        if self.buffer.distance(head, self.tail.get()) < n {
+            // Refresh the tail ...
+            let tail = self.buffer.tail.load(Ordering::Acquire);
+            self.tail.set(tail);
+
+            // ... and check if there *really* are not enough slots.
+            let slots = self.buffer.distance(head, tail);
+            if slots < n {
+                return Err(ChunkError::TooFewSlots(slots));
+            }
+        }
+
+        let head = self.buffer.collapse_position(head);
+        let first_len = n.min(self.buffer.capacity - head);
+        Ok(ReadChunk {
+            first_ptr: unsafe { self.buffer.data_ptr.add(head) },
+            first_len,
+            second_ptr: self.buffer.data_ptr,
+            second_len: n - first_len,
+            consumer: self,
+            iterated: 0,
+        })
+    }
+}
+
+/// Structure for writing into multiple ([`Default`]-initialized) slots in one go.
+///
+/// This is returned from [`Producer::write_chunk()`].
+///
+/// For an unsafe alternative that provides uninitialized slots,
+/// see [`WriteChunkUninit`].
+///
+/// The slots (which initially contain [`Default`] values) can be accessed with
+/// [`as_mut_slices()`](WriteChunk::as_mut_slices)
+/// or by iteration, which yields mutable references (in other words: `&mut T`).
+/// A mutable reference (`&mut`) to the `WriteChunk`
+/// should be used to iterate over it.
+/// Each slot can only be iterated once and the number of iterations is tracked.
+///
+/// After writing, the provided slots are *not* automatically made available
+/// to be read by the [`Consumer`].
+/// If desired, this has to be explicitly done by calling
+/// [`commit()`](WriteChunk::commit),
+/// [`commit_iterated()`](WriteChunk::commit_iterated) or
+/// [`commit_all()`](WriteChunk::commit_all).
+#[derive(Debug)]
+pub struct WriteChunk<'a, T>(WriteChunkUninit<'a, T>);
+
+impl<'a, T> From<WriteChunkUninit<'a, T>> for WriteChunk<'a, T>
+where
+    T: Copy + Default,
+{
+    /// Fills all slots with the [`Default`] value.
+    fn from(chunk: WriteChunkUninit<'a, T>) -> Self {
+        for i in 0..chunk.first_len {
+            unsafe {
+                chunk.first_ptr.add(i).write(Default::default());
+            }
+        }
+        for i in 0..chunk.second_len {
+            unsafe {
+                chunk.second_ptr.add(i).write(Default::default());
+            }
+        }
+        WriteChunk(chunk)
+    }
+}
+
+impl<T> WriteChunk<'_, T>
+where
+    T: Copy + Default,
+{
+    /// Returns two slices for writing to the requested slots.
+    ///
+    /// All slots are initially filled with their [`Default`] value.
+    ///
+    /// The first slice can only be empty if `0` slots have been requested.
+    /// If the first slice contains all requested slots, the second one is empty.
+    ///
+    /// See [`RingBuffer::with_chunks()`] for a way to make sure
+    /// that the second slice is always empty.
+    pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
+        // Safety: All slots have been initialized in From::from().
+        unsafe {
+            (
+                core::slice::from_raw_parts_mut(self.0.first_ptr, self.0.first_len),
+                core::slice::from_raw_parts_mut(self.0.second_ptr, self.0.second_len),
+            )
+        }
+    }
+
+    /// Makes the first `n` slots of the chunk available for reading.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is greater than the number of slots in the chunk.
+    pub fn commit(self, n: usize) {
+        // Safety: All slots have been initialized in From::from() and there are no destructors.
+        unsafe { self.0.commit(n) }
+    }
+
+    /// Returns the number of iterated slots and makes them available for reading.
+    pub fn commit_iterated(self) -> usize {
+        // Safety: All slots have been initialized in From::from() and there are no destructors.
+        unsafe { self.0.commit_iterated() }
+    }
+
+    /// Makes the whole chunk available for reading.
+    pub fn commit_all(self) {
+        // Safety: All slots have been initialized in From::from().
+        unsafe { self.0.commit_all() }
+    }
+
+    /// Returns the number of slots in the chunk.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the chunk contains no slots.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl<'a, T> Iterator for WriteChunk<'a, T>
+where
+    T: Copy + Default,
+{
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|item| {
+            // Safety: All slots have been initialized in From::from().
+            unsafe { &mut *item.as_mut_ptr() }
+        })
+    }
+}
+
+/// Structure for writing into multiple (uninitialized) slots in one go.
+///
+/// This is returned from [`Producer::write_chunk_uninit()`].
+///
+/// For a safe alternative that provides [`Default`]-initialized slots, see [`WriteChunk`].
+///
+/// The slots can be accessed with
+/// [`as_mut_slices()`](WriteChunkUninit::as_mut_slices)
+/// or by iteration, which yields mutable references to possibly uninitialized data
+/// (in other words: `&mut MaybeUninit<T>`).
+/// A mutable reference (`&mut`) to the `WriteChunkUninit`
+/// should be used to iterate over it.
+/// Each slot can only be iterated once and the number of iterations is tracked.
+///
+/// After writing, the provided slots are *not* automatically made available
+/// to be read by the [`Consumer`].
+/// If desired, this has to be explicitly done by calling
+/// [`commit()`](WriteChunkUninit::commit),
+/// [`commit_iterated()`](WriteChunkUninit::commit_iterated) or
+/// [`commit_all()`](WriteChunkUninit::commit_all).
+#[derive(Debug)]
+pub struct WriteChunkUninit<'a, T> {
+    first_ptr: *mut T,
+    first_len: usize,
+    second_ptr: *mut T,
+    second_len: usize,
+    producer: &'a Producer<T>,
+    iterated: usize,
+}
+
+impl<T> WriteChunkUninit<'_, T> {
+    /// Returns two slices for writing to the requested slots.
+    ///
+    /// The first slice can only be empty if `0` slots have been requested.
+    /// If the first slice contains all requested slots, the second one is empty.
+    ///
+    /// See [`RingBuffer::with_chunks()`] for a way to make sure
+    /// that the second slice is always empty.
+    ///
+    /// The extension trait [`CopyToUninit`] can be used to safely copy data into those slices.
+    pub fn as_mut_slices(&mut self) -> (&mut [MaybeUninit<T>], &mut [MaybeUninit<T>]) {
+        unsafe {
+            (
+                core::slice::from_raw_parts_mut(self.first_ptr as *mut _, self.first_len),
+                core::slice::from_raw_parts_mut(self.second_ptr as *mut _, self.second_len),
+            )
+        }
+    }
+
+    /// Makes the first `n` slots of the chunk available for reading.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is greater than the number of slots in the chunk.
+    ///
+    /// # Safety
+    ///
+    /// The user must make sure that the first `n` elements
+    /// (and not more, in case `T` implements [`Drop`]) have been initialized.
+    pub unsafe fn commit(self, n: usize) {
+        assert!(n <= self.len(), "cannot commit more than chunk size");
+        self.commit_unchecked(n);
+    }
+
+    /// Returns the number of iterated slots and makes them available for reading.
+    ///
+    /// # Safety
+    ///
+    /// The user must make sure that all iterated elements have been initialized.
+    pub unsafe fn commit_iterated(self) -> usize {
+        let slots = self.iterated;
+        self.commit_unchecked(slots)
+    }
+
+    /// Makes the whole chunk available for reading.
+    ///
+    /// # Safety
+    ///
+    /// The user must make sure that all elements have been initialized.
+    pub unsafe fn commit_all(self) {
+        let slots = self.len();
+        self.commit_unchecked(slots);
+    }
+
+    unsafe fn commit_unchecked(self, n: usize) -> usize {
+        let tail = self.producer.buffer.increment(self.producer.tail.get(), n);
+        self.producer.buffer.tail.store(tail, Ordering::Release);
+        self.producer.tail.set(tail);
+        n
+    }
+
+    /// Returns the number of slots in the chunk.
+    pub fn len(&self) -> usize {
+        self.first_len + self.second_len
+    }
+
+    /// Returns `true` if the chunk contains no slots.
+    pub fn is_empty(&self) -> bool {
+        self.first_len == 0
+    }
+}
+
+impl<'a, T> Iterator for WriteChunkUninit<'a, T> {
+    type Item = &'a mut MaybeUninit<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let ptr = if self.iterated < self.first_len {
+            unsafe { self.first_ptr.add(self.iterated) }
+        } else if self.iterated < self.first_len + self.second_len {
+            unsafe { self.second_ptr.add(self.iterated - self.first_len) }
+        } else {
+            return None;
+        };
+        self.iterated += 1;
+        Some(unsafe { &mut *(ptr as *mut _) })
+    }
+}
+
+/// Structure for reading from multiple slots in one go.
+///
+/// This is returned from [`Consumer::read_chunk()`].
+///
+/// The slots can be accessed with [`as_slices()`](ReadChunk::as_slices)
+/// or by iteration.
+/// Even though iterating yields immutable references (`&T`),
+/// a mutable reference (`&mut`) to the `ReadChunk` should be used to iterate over it.
+/// Each slot can only be iterated once and the number of iterations is tracked.
+///
+/// After reading, the provided slots are *not* automatically made available
+/// to be written again by the [`Producer`].
+/// If desired, this has to be explicitly done by calling [`commit()`](ReadChunk::commit),
+/// [`commit_iterated()`](ReadChunk::commit_iterated) or [`commit_all()`](ReadChunk::commit_all).
+/// Note that this runs the destructor of the committed items (if `T` implements [`Drop`]).
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReadChunk<'a, T> {
+    first_ptr: *const T,
+    first_len: usize,
+    second_ptr: *const T,
+    second_len: usize,
+    consumer: &'a mut Consumer<T>,
+    iterated: usize,
+}
+
+impl<T> ReadChunk<'_, T> {
+    /// Returns two slices for reading from the requested slots.
+    ///
+    /// The first slice can only be empty if `0` slots have been requested.
+    /// If the first slice contains all requested slots, the second one is empty.
+    ///
+    /// See [`RingBuffer::with_chunks()`] for a way to make sure
+    /// that the second slice is always empty.
+    pub fn as_slices(&self) -> (&[T], &[T]) {
+        (
+            unsafe { core::slice::from_raw_parts(self.first_ptr, self.first_len) },
+            unsafe { core::slice::from_raw_parts(self.second_ptr, self.second_len) },
+        )
+    }
+
+    /// Drops the first `n` slots of the chunk, making the space available for writing again.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is greater than the number of slots in the chunk.
+    pub fn commit(self, n: usize) {
+        assert!(n <= self.len(), "cannot commit more than chunk size");
+        unsafe { self.commit_unchecked(n) };
+    }
+
+    /// Drops all slots that have been iterated, making the space available for writing again.
+    ///
+    /// Returns the number of iterated slots.
+    pub fn commit_iterated(self) -> usize {
+        let slots = self.iterated;
+        unsafe { self.commit_unchecked(slots) }
+    }
+
+    /// Drops all slots of the chunk, making the space available for writing again.
+    pub fn commit_all(self) {
+        let slots = self.len();
+        unsafe { self.commit_unchecked(slots) };
+    }
+
+    unsafe fn commit_unchecked(self, n: usize) -> usize {
+        let head = self.consumer.head.get();
+        // Safety: head has not yet been incremented
+        let ptr = self.consumer.buffer.slot_ptr(head);
+        let first_len = self.first_len.min(n);
+        for i in 0..first_len {
+            ptr.add(i).drop_in_place();
+        }
+        let ptr = self.consumer.buffer.data_ptr;
+        let second_len = self.second_len.min(n - first_len);
+        for i in 0..second_len {
+            ptr.add(i).drop_in_place();
+        }
+        let head = self.consumer.buffer.increment(head, n);
+        self.consumer.buffer.head.store(head, Ordering::Release);
+        self.consumer.head.set(head);
+        n
+    }
+
+    /// Returns the number of slots in the chunk.
+    pub fn len(&self) -> usize {
+        self.first_len + self.second_len
+    }
+
+    /// Returns `true` if the chunk contains no slots.
+    pub fn is_empty(&self) -> bool {
+        self.first_len == 0
+    }
+}
+
+impl<'a, T> Iterator for ReadChunk<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let ptr = if self.iterated < self.first_len {
+            unsafe { self.first_ptr.add(self.iterated) }
+        } else if self.iterated < self.first_len + self.second_len {
+            unsafe { self.second_ptr.add(self.iterated - self.first_len) }
+        } else {
+            return None;
+        };
+        self.iterated += 1;
+        Some(unsafe { &*ptr })
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Write for Producer<u8> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        use ChunkError::TooFewSlots;
+        let mut chunk = match self.write_chunk_uninit(buf.len()) {
+            Ok(chunk) => chunk,
+            Err(TooFewSlots(0)) => return Err(std::io::ErrorKind::WouldBlock.into()),
+            Err(TooFewSlots(n)) => self.write_chunk_uninit(n).unwrap(),
+        };
+        let end = chunk.len();
+        let (first, second) = chunk.as_mut_slices();
+        let mid = first.len();
+        // NB: If buf.is_empty(), chunk will be empty as well and the following are no-ops:
+        buf[..mid].copy_to_uninit(first);
+        buf[mid..end].copy_to_uninit(second);
+        // Safety: All slots have been initialized
+        unsafe {
+            chunk.commit_all();
+        }
+        Ok(end)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // Nothing to do here.
+        Ok(())
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Read for Consumer<u8> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        use ChunkError::TooFewSlots;
+        let chunk = match self.read_chunk(buf.len()) {
+            Ok(chunk) => chunk,
+            Err(TooFewSlots(0)) => return Err(std::io::ErrorKind::WouldBlock.into()),
+            Err(TooFewSlots(n)) => self.read_chunk(n).unwrap(),
+        };
+        let (first, second) = chunk.as_slices();
+        let mid = first.len();
+        let end = chunk.len();
+        // NB: If buf.is_empty(), chunk will be empty as well and the following are no-ops:
+        buf[..mid].copy_from_slice(first);
+        buf[mid..end].copy_from_slice(second);
+        chunk.commit_all();
+        Ok(end)
+    }
+}
+
+/// Error type for [`Consumer::read_chunk()`], [`Producer::write_chunk()`]
+/// and [`Producer::write_chunk_uninit()`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ChunkError {
+    /// Fewer than the requested number of slots were available.
+    ///
+    /// Contains the number of slots that were available.
+    TooFewSlots(usize),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ChunkError {}
+
+impl fmt::Display for ChunkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ChunkError::TooFewSlots(n) => {
+                alloc::format!("only {} slots available in ring buffer", n).fmt(f)
+            }
+        }
+    }
+}

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -1,9 +1,12 @@
-//! Writing and reading chunks of data into and from a [`RingBuffer`].
+//! Writing and reading multiple items at once into and from a [`RingBuffer`].
 //!
 //! Multiple items can be written at once by using [`Producer::write_chunk()`]
 //! or its `unsafe` (but probably slightly faster) cousin [`Producer::write_chunk_uninit()`].
 //!
 //! Multiple items can be read at once with [`Consumer::read_chunk()`].
+//!
+//! If all chunks have the same size, the [`fixed_chunks`](crate::fixed_chunks) module
+//! can be used instead.
 //!
 //! # Examples
 //!
@@ -15,7 +18,7 @@
 //! ```
 //! use rtrb::RingBuffer;
 //!
-//! let (mut producer, mut consumer) = RingBuffer::new(5).split();
+//! let (mut producer, mut consumer) = RingBuffer::new(5);
 //!
 //! if let Ok(mut chunk) = producer.write_chunk(4) {
 //!     // NB: Don't use `chunk` as the first iterator in zip() if the other one might be shorter!
@@ -76,7 +79,7 @@
 //! The following examples show the [`Producer`] side;
 //! similar patterns can of course be used with [`Consumer::read_chunk()`] as well.
 //! Furthermore, the examples use [`Producer::write_chunk()`],
-//! which requires the trait bounds `T: Copy + Default`.
+//! which requires the trait bound `T: Default`.
 //! If that's too restrictive or if you want to squeeze out the last bit of performance,
 //! you can use [`Producer::write_chunk_uninit()`] instead,
 //! but this will force you to write some `unsafe` code.
@@ -139,7 +142,7 @@
 //!
 //! fn push_from_iter<T, I>(queue: &mut Producer<T>, iter: &mut I) -> usize
 //! where
-//!     T: Copy + Default,
+//!     T: Default,
 //!     I: Iterator<Item = T>,
 //! {
 //!     let n = match iter.size_hint() {
@@ -164,30 +167,14 @@ use core::fmt;
 use core::mem::MaybeUninit;
 use core::sync::atomic::Ordering;
 
-use crate::{Consumer, CopyToUninit, Producer, RingBuffer};
+use crate::{Consumer, CopyToUninit, Producer};
 
-impl<T> RingBuffer<T> {
-    /// Creates a `RingBuffer` with a capacity of `chunks * chunk_size`.
-    ///
-    /// On top of multiplying the two numbers for us,
-    /// this also guarantees that the ring buffer wrap-around happens
-    /// at an integer multiple of `chunk_size`.
-    /// This means that if [`Consumer::read_chunk()`] is used *exclusively* with
-    /// `chunk_size` (and [`Consumer::pop()`] is *not* used in-between),
-    /// the first slice returned from [`ReadChunk::as_slices()`]
-    /// will always contain the entire chunk and the second slice will always be empty.
-    /// Same for [`Producer::write_chunk()`]/[`WriteChunk::as_mut_slices()`] and
-    /// [`Producer::write_chunk_uninit()`]/[`WriteChunkUninit::as_mut_slices()`]
-    /// (as long as [`Producer::push()`] is *not* used in-between).
-    ///
-    /// If above conditions have been violated, the wrap-around guarantee can be restored
-    /// wit [`reset()`](RingBuffer::reset).
-    pub fn with_chunks(chunks: usize, chunk_size: usize) -> RingBuffer<T> {
-        // NB: Currently, there is nothing special to do here, but in the future
-        //     it might be necessary to take some steps to guarantee the promised behavior.
-        Self::new(chunks * chunk_size)
-    }
-}
+// This is used in the documentation.
+#[allow(unused_imports)]
+use crate::{
+    fixed_chunks::{ChunkConsumer, ChunkProducer},
+    RingBuffer,
+};
 
 impl<T> Producer<T> {
     /// Returns `n` slots (initially containing their [`Default`] value) for writing.
@@ -203,19 +190,15 @@ impl<T> Producer<T> {
     /// This has to be explicitly done by calling [`WriteChunk::commit()`],
     /// [`WriteChunk::commit_iterated()`] or [`WriteChunk::commit_all()`].
     ///
-    /// The type parameter `T` has a trait bound of [`Copy`],
-    /// which makes sure that no destructors are called at any time
-    /// (because it implies [`!Drop`](Drop)).
-    ///
     /// For an unsafe alternative that has no restrictions on `T`,
     /// see [`Producer::write_chunk_uninit()`].
     ///
     /// # Examples
     ///
-    /// See the [module-level documentation](crate::chunks#examples) for examples.
+    /// See the documentation of the [`chunks`](crate::chunks#examples) module for more examples.
     pub fn write_chunk(&mut self, n: usize) -> Result<WriteChunk<'_, T>, ChunkError>
     where
-        T: Copy + Default,
+        T: Default,
     {
         self.write_chunk_uninit(n).map(WriteChunk::from)
     }
@@ -242,6 +225,20 @@ impl<T> Producer<T> {
     /// For a safe alternative that provides [`Default`]-initialized slots,
     /// see [`Producer::write_chunk()`].
     pub fn write_chunk_uninit(&mut self, n: usize) -> Result<WriteChunkUninit<'_, T>, ChunkError> {
+        let tail = self.check_chunk(n)?;
+        let first_len = n.min(self.buffer.capacity - tail);
+        Ok(WriteChunkUninit {
+            first_ptr: unsafe { self.buffer.data_ptr.add(tail) },
+            first_len,
+            second_ptr: self.buffer.data_ptr,
+            second_len: n - first_len,
+            producer: self,
+            iterated: 0,
+        })
+    }
+
+    /// Returns (possibly wrapped-around) tail position after `n` slots (if available).
+    pub(crate) fn check_chunk(&self, n: usize) -> Result<usize, ChunkError> {
         let tail = self.tail.get();
 
         // Check if the queue has *possibly* not enough slots.
@@ -256,16 +253,7 @@ impl<T> Producer<T> {
                 return Err(ChunkError::TooFewSlots(slots));
             }
         }
-        let tail = self.buffer.collapse_position(tail);
-        let first_len = n.min(self.buffer.capacity - tail);
-        Ok(WriteChunkUninit {
-            first_ptr: unsafe { self.buffer.data_ptr.add(tail) },
-            first_len,
-            second_ptr: self.buffer.data_ptr,
-            second_len: n - first_len,
-            producer: self,
-            iterated: 0,
-        })
+        Ok(self.buffer.collapse_position(tail))
     }
 }
 
@@ -304,7 +292,7 @@ impl<T> Consumer<T> {
     ///
     /// // Scope to limit lifetime of ring buffer
     /// {
-    ///     let (mut p, mut c) = RingBuffer::new(2).split();
+    ///     let (mut p, mut c) = RingBuffer::new(2);
     ///
     ///     assert!(p.push(Thing).is_ok()); // 1
     ///     assert!(p.push(Thing).is_ok()); // 2
@@ -333,10 +321,23 @@ impl<T> Consumer<T> {
     /// assert_eq!(unsafe { DROP_COUNT }, 3);
     /// ```
     ///
-    /// See the [module-level documentation](crate::chunks#examples) for more examples.
+    /// See the documentation of the [`chunks`](crate::chunks#examples) module for more examples.
     pub fn read_chunk(&mut self, n: usize) -> Result<ReadChunk<'_, T>, ChunkError> {
-        let head = self.head.get();
+        let head = self.check_chunk(n)?;
+        let first_len = n.min(self.buffer.capacity - head);
+        Ok(ReadChunk {
+            first_ptr: unsafe { self.buffer.data_ptr.add(head) },
+            first_len,
+            second_ptr: self.buffer.data_ptr,
+            second_len: n - first_len,
+            consumer: self,
+            iterated: 0,
+        })
+    }
 
+    /// Returns (possibly wrapped-around) head position after `n` slots (if available).
+    pub(crate) fn check_chunk(&self, n: usize) -> Result<usize, ChunkError> {
+        let head = self.head.get();
         // Check if the queue has *possibly* not enough slots.
         if self.buffer.distance(head, self.tail.get()) < n {
             // Refresh the tail ...
@@ -349,17 +350,7 @@ impl<T> Consumer<T> {
                 return Err(ChunkError::TooFewSlots(slots));
             }
         }
-
-        let head = self.buffer.collapse_position(head);
-        let first_len = n.min(self.buffer.capacity - head);
-        Ok(ReadChunk {
-            first_ptr: unsafe { self.buffer.data_ptr.add(head) },
-            first_len,
-            second_ptr: self.buffer.data_ptr,
-            second_len: n - first_len,
-            consumer: self,
-            iterated: 0,
-        })
+        Ok(self.buffer.collapse_position(head))
     }
 }
 
@@ -383,12 +374,12 @@ impl<T> Consumer<T> {
 /// [`commit()`](WriteChunk::commit),
 /// [`commit_iterated()`](WriteChunk::commit_iterated) or
 /// [`commit_all()`](WriteChunk::commit_all).
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct WriteChunk<'a, T>(WriteChunkUninit<'a, T>);
 
 impl<'a, T> From<WriteChunkUninit<'a, T>> for WriteChunk<'a, T>
 where
-    T: Copy + Default,
+    T: Default,
 {
     /// Fills all slots with the [`Default`] value.
     fn from(chunk: WriteChunkUninit<'a, T>) -> Self {
@@ -408,7 +399,7 @@ where
 
 impl<T> WriteChunk<'_, T>
 where
-    T: Copy + Default,
+    T: Default,
 {
     /// Returns two slices for writing to the requested slots.
     ///
@@ -416,9 +407,6 @@ where
     ///
     /// The first slice can only be empty if `0` slots have been requested.
     /// If the first slice contains all requested slots, the second one is empty.
-    ///
-    /// See [`RingBuffer::with_chunks()`] for a way to make sure
-    /// that the second slice is always empty.
     pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
         // Safety: All slots have been initialized in From::from().
         unsafe {
@@ -464,7 +452,7 @@ where
 
 impl<'a, T> Iterator for WriteChunk<'a, T>
 where
-    T: Copy + Default,
+    T: Default,
 {
     type Item = &'a mut T;
 
@@ -496,7 +484,7 @@ where
 /// [`commit()`](WriteChunkUninit::commit),
 /// [`commit_iterated()`](WriteChunkUninit::commit_iterated) or
 /// [`commit_all()`](WriteChunkUninit::commit_all).
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct WriteChunkUninit<'a, T> {
     first_ptr: *mut T,
     first_len: usize,
@@ -511,9 +499,6 @@ impl<T> WriteChunkUninit<'_, T> {
     ///
     /// The first slice can only be empty if `0` slots have been requested.
     /// If the first slice contains all requested slots, the second one is empty.
-    ///
-    /// See [`RingBuffer::with_chunks()`] for a way to make sure
-    /// that the second slice is always empty.
     ///
     /// The extension trait [`CopyToUninit`] can be used to safely copy data into those slices.
     pub fn as_mut_slices(&mut self) -> (&mut [MaybeUninit<T>], &mut [MaybeUninit<T>]) {
@@ -624,9 +609,6 @@ impl<T> ReadChunk<'_, T> {
     ///
     /// The first slice can only be empty if `0` slots have been requested.
     /// If the first slice contains all requested slots, the second one is empty.
-    ///
-    /// See [`RingBuffer::with_chunks()`] for a way to make sure
-    /// that the second slice is always empty.
     pub fn as_slices(&self) -> (&[T], &[T]) {
         (
             unsafe { core::slice::from_raw_parts(self.first_ptr, self.first_len) },
@@ -754,8 +736,15 @@ impl std::io::Read for Consumer<u8> {
     }
 }
 
-/// Error type for [`Consumer::read_chunk()`], [`Producer::write_chunk()`]
-/// and [`Producer::write_chunk_uninit()`].
+/// Error type for chunk-related functions.
+///
+/// * [`Producer::write_chunk()`]
+/// * [`Producer::write_chunk_uninit()`]
+/// * [`Consumer::read_chunk()`]
+/// * [`ChunkProducer::push_chunk()`]
+/// * [`ChunkProducer::push_chunk_uninit()`]
+/// * [`ChunkConsumer::pop_chunk()`]
+/// * [`ChunkConsumer::peek_chunk()`]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ChunkError {
     /// Fewer than the requested number of slots were available.

--- a/src/fixed_chunks.rs
+++ b/src/fixed_chunks.rs
@@ -1,0 +1,535 @@
+//! Writing and reading fixed-size chunks into and from a [`RingBuffer`].
+//!
+//! An appropriately sized [`RingBuffer`] can be created with
+//! [`RingBuffer::with_chunks(...).of_size(...)`](RingBuffer::with_chunks).
+//!
+//! Chunks can be produced by using [`ChunkProducer::push_chunk()`]
+//! or its `unsafe` (but probably slightly faster) cousin [`ChunkProducer::push_chunk_uninit()`].
+//!
+//! Chunks can be consumed with [`ChunkConsumer::pop_chunk()`].
+//!
+//! Since only fixed-size chunks are allowed, all chunks are guaranteed to be contiguous in memory.
+//! This is not the case for [`Producer::write_chunk()`], [`Producer::write_chunk_uninit()`] and
+//! [`Consumer::read_chunk()`], where the ring buffer wrap-around
+//! might cause any chunk to be stored in two separate slices.
+//!
+//! If not all chunks have the same size, or if individual elements should be handled as well,
+//! the [`chunks`](crate::chunks) module can be used instead.
+//!
+//! # Examples
+//!
+//! The following examples use a single thread for simplicity, but in a real application,
+//! the producer and consumer side would of course live on different threads.
+//!
+//! Producing single items, consuming chunks:
+//!
+//! ```
+//! use rtrb::{RingBuffer, Producer, fixed_chunks::ChunkConsumer};
+//!
+//! let (mut p, mut c): (Producer<_>, ChunkConsumer<_>) = RingBuffer::with_chunks(3).of_size(2);
+//! p.push(10).unwrap();
+//! p.push(11).unwrap();
+//! p.push(12).unwrap();
+//! p.push(13).unwrap();
+//!
+//! if let Ok(chunk) = c.pop_chunk() {
+//!     assert_eq!(*chunk, [10, 11]);
+//! } else {
+//!     unreachable!();
+//! }
+//! if let Ok(chunk) = c.peek_chunk() {
+//!     assert_eq!(chunk, [12, 13]);
+//! } else {
+//!     unreachable!();
+//! }
+//! if let Ok(chunk) = c.pop_chunk() {
+//!     assert_eq!(chunk.len(), 2);
+//!     assert_eq!(chunk[0], 12);
+//!     assert_eq!(chunk[1], 13);
+//! } else {
+//!     unreachable!();
+//! }
+//! assert_eq!(c.pop_chunk(), Err(rtrb::fixed_chunks::ChunkError::TooFewSlots(0)));
+//! ```
+//!
+//! Producing chunks, consuming single items:
+//!
+//! ```
+//! use rtrb::{RingBuffer, fixed_chunks::ChunkProducer, Consumer};
+//!
+//! let (mut p, mut c): (ChunkProducer<_>, Consumer<_>) = RingBuffer::with_chunks(3).of_size(2);
+//!
+//! if let Ok(mut chunk) = p.push_chunk() {
+//!     chunk.copy_from_slice(&[10, 11]);
+//! } else {
+//!     unreachable!();
+//! }
+//! if let Ok(mut chunk) = p.push_chunk() {
+//!     assert_eq!(chunk.len(), 2);
+//!     chunk[0] = 12;
+//!     chunk[1] = 13;
+//! } else {
+//!     unreachable!();
+//! }
+//!
+//! use rtrb::CopyToUninit as _; // This is needed for copy_to_uninit().
+//!
+//! // Safety: chunk will be initialized before it's dropped.
+//! if let Ok(mut chunk) = unsafe { p.push_chunk_uninit() } {
+//!     [14, 15].copy_to_uninit(&mut chunk);
+//! } else {
+//!     unreachable!();
+//! }
+//!
+//! assert_eq!(p.push_chunk(), Err(rtrb::fixed_chunks::ChunkError::TooFewSlots(0)));
+//!
+//! assert_eq!(c.pop(), Ok(10));
+//! assert_eq!(c.pop(), Ok(11));
+//! assert_eq!(c.pop(), Ok(12));
+//! assert_eq!(c.pop(), Ok(13));
+//! assert_eq!(c.pop(), Ok(14));
+//! assert_eq!(c.pop(), Ok(15));
+//! ```
+//!
+//! And finally, producing and consuming chunks:
+//!
+//! ```
+//! use rtrb::{RingBuffer, fixed_chunks::ChunkProducer, fixed_chunks::ChunkConsumer};
+//!
+//! let (mut p, mut c): (ChunkProducer<_>, ChunkConsumer<_>) =
+//!     RingBuffer::with_chunks(3).of_size(2);
+//!
+//! if let Ok(mut chunk) = p.push_chunk() {
+//!     chunk.copy_from_slice(&[10, 11]);
+//! } else {
+//!     unreachable!();
+//! }
+//! if let Ok(chunk) = c.pop_chunk() {
+//!     assert_eq!(chunk.as_ref(), [10, 11]);
+//! } else {
+//!     unreachable!();
+//! }
+//! assert_eq!(c.peek_chunk(), Err(rtrb::fixed_chunks::ChunkError::TooFewSlots(0)));
+//! ```
+
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::ops::{Deref, DerefMut};
+use core::sync::atomic::Ordering;
+
+use crate::{Consumer, Producer, RingBuffer};
+
+pub use crate::chunks::ChunkError;
+
+impl<T> RingBuffer<T> {
+    /// Creates a `RingBuffer` with the given number of fixed-size chunks.
+    ///
+    /// The call to `with_chunks(...)` has to be followed by `.of_size(...)`,
+    /// which will return a pair of producer and consumer.
+    /// Multiple combinations of return types are possible:
+    ///
+    /// * `(`[`Producer<T>`]`, `[`ChunkConsumer<T>`]`)`
+    /// * `(`[`ChunkProducer<T>`]`, `[`Consumer<T>`]`)`
+    /// * `(`[`ChunkProducer<T>`]`, `[`ChunkConsumer<T>`]`)`
+    ///
+    /// The desired combination can be selected with type annotations.
+    ///
+    /// The remaining possible combination `(`[`Producer<T>`]`, `[`Consumer<T>`]`)`
+    /// can be created with [`RingBuffer::new()`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rtrb::{fixed_chunks::ChunkConsumer, Producer, RingBuffer};
+    ///
+    /// let (p, c): (Producer<_>, ChunkConsumer<_>) = RingBuffer::<f32>::with_chunks(7).of_size(8);
+    /// ```
+    ///
+    /// Typically, the producer and consumer are stored somewhere (probably in a `struct`).
+    /// Since the return types are known in this case, no type annotations are necessary
+    /// when calling `RingBuffer::with_chunks(...).of_size(...)`:
+    ///
+    /// ```
+    /// use rtrb::{fixed_chunks::ChunkProducer, Consumer, RingBuffer};
+    ///
+    /// struct OneThing {
+    ///     producer: ChunkProducer<f32>,
+    /// }
+    /// struct AnotherThing {
+    ///     consumer: Consumer<f32>,
+    /// }
+    ///
+    /// let (producer, consumer) = RingBuffer::with_chunks(100).of_size(64);
+    ///
+    /// let thing1 = OneThing { producer };
+    /// let thing2 = AnotherThing { consumer };
+    /// ```
+    ///
+    /// See the documentation of the [`fixed_chunks`](crate::fixed_chunks#examples) module
+    /// for more examples.
+    pub fn with_chunks(chunks: usize) -> Builder<T> {
+        Builder {
+            chunks,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct Builder<T> {
+    chunks: usize,
+    _phantom: PhantomData<*mut T>,
+}
+
+impl<T> Builder<T> {
+    /// part of with_chunks(...).of_size(...)
+    pub fn of_size<R>(self, chunk_size: usize) -> R
+    where
+        R: ChunkyRingBufferParts<T>,
+    {
+        R::from_chunks_and_chunk_size::<private::NotPublic>(self.chunks, chunk_size)
+    }
+}
+
+// https://jack.wrenn.fyi/blog/private-trait-methods/
+pub(crate) mod private {
+    pub enum NotPublic {}
+    pub trait IsPrivate {}
+    impl IsPrivate for NotPublic {}
+}
+
+#[doc(hidden)]
+pub trait ChunkyRingBufferParts<T> {
+    fn from_chunks_and_chunk_size<L>(chunks: usize, chunk_size: usize) -> Self
+    where
+        L: private::IsPrivate;
+}
+
+impl<T> ChunkyRingBufferParts<T> for (ChunkProducer<T>, Consumer<T>) {
+    fn from_chunks_and_chunk_size<L>(chunks: usize, chunk_size: usize) -> Self
+    where
+        L: private::IsPrivate,
+    {
+        let (p, c) = RingBuffer::new(chunks * chunk_size);
+        let p = ChunkProducer {
+            inner: p,
+            chunk_size,
+        };
+        (p, c)
+    }
+}
+
+impl<T> ChunkyRingBufferParts<T> for (Producer<T>, ChunkConsumer<T>) {
+    fn from_chunks_and_chunk_size<L>(chunks: usize, chunk_size: usize) -> Self
+    where
+        L: private::IsPrivate,
+    {
+        let (p, c) = RingBuffer::new(chunks * chunk_size);
+        let c = ChunkConsumer {
+            inner: c,
+            chunk_size,
+        };
+        (p, c)
+    }
+}
+
+impl<T> ChunkyRingBufferParts<T> for (ChunkProducer<T>, ChunkConsumer<T>) {
+    fn from_chunks_and_chunk_size<L>(chunks: usize, chunk_size: usize) -> Self
+    where
+        L: private::IsPrivate,
+    {
+        let (p, c) = RingBuffer::new(chunks * chunk_size);
+        let p = ChunkProducer {
+            inner: p,
+            chunk_size,
+        };
+        let c = ChunkConsumer {
+            inner: c,
+            chunk_size,
+        };
+        (p, c)
+    }
+}
+
+/// The producer side of a [`RingBuffer`], using fixed-size chunks.
+///
+/// Can be moved between threads,
+/// but references from different threads are not allowed
+/// (i.e. it is [`Send`] but not [`Sync`]).
+///
+/// Can be created with [`RingBuffer::with_chunks(...).of_size(...)`](RingBuffer::with_chunks)
+/// (together with one of its counterparts [`Consumer`] or [`ChunkConsumer`]).
+///
+/// Fixed-size chunks can be produced with [`ChunkProducer::push_chunk()`] or its `unsafe`
+/// (but probably slightly faster) cousin [`ChunkProducer::push_chunk_uninit()`].
+///
+/// If not all chunks have the same size, or if individual elements should be produced,
+/// a [`Producer`] can be used instead.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ChunkProducer<T> {
+    inner: Producer<T>,
+    chunk_size: usize,
+}
+
+unsafe impl<T: Send> Send for ChunkProducer<T> {}
+
+impl<T> ChunkProducer<T> {
+    /// Returns a [`Default`]-initialized fixed-size chunk for writing,
+    /// advancing the write position when dropped.
+    ///
+    /// If not enough data for a full chunk is available, an error is returned.
+    ///
+    /// For mutable access to its contents, the returned [`PushChunk<T>`]
+    /// can be (auto-)dereferenced to a [`slice`].
+    ///
+    /// When the returned [`PushChunk<T>`] is dropped, all slots are made available for reading.
+    ///
+    /// If uninitialized chunks are desired, [`ChunkProducer::push_chunk_uninit()`] can be used.
+    ///
+    /// # Examples
+    ///
+    /// For examples see the documentation of the
+    /// [`fixed_chunks`](crate::fixed_chunks#examples) module.
+    pub fn push_chunk(&mut self) -> Result<PushChunk<'_, T>, ChunkError>
+    where
+        T: Default,
+    {
+        // Safety: PushChunk::from() initializes all slots.
+        unsafe { self.push_chunk_uninit().map(PushChunk::from) }
+    }
+
+    /// Returns an uninitialized fixed-size chunk for writing,
+    /// advancing the write position when dropped.
+    ///
+    /// If not enough data for a full chunk is available, an error is returned.
+    ///
+    /// For mutable access to its contents, the returned [`PushChunkUninit<T>`]
+    /// can be (auto-)dereferenced to a [`slice`] of [`MaybeUninit<T>`].
+    ///
+    /// When the returned [`PushChunkUninit<T>`] is dropped,
+    /// all slots are made available for reading.
+    /// At this time, the whole chunk has to be initialized.
+    ///
+    /// If [`Default`]-initialized chunks are desired, [`ChunkProducer::push_chunk()`] can be used.
+    ///
+    /// # Safety
+    ///
+    /// Calling this function is safe, but dropping the returned [`PushChunkUninit`]
+    /// (which might also happen in case of a panic!)
+    /// is only safe if all slots have been initialized.
+    ///
+    /// # Examples
+    ///
+    /// For examples see the documentation of the
+    /// [`fixed_chunks`](crate::fixed_chunks#examples) module.
+    pub unsafe fn push_chunk_uninit(&mut self) -> Result<PushChunkUninit<'_, T>, ChunkError> {
+        let tail = self.inner.check_chunk(self.chunk_size)?;
+        debug_assert!(self.chunk_size <= self.inner.buffer.capacity - tail);
+        Ok(PushChunkUninit {
+            ptr: self.inner.buffer.data_ptr.add(tail),
+            len: self.chunk_size,
+            producer: &mut self.inner,
+        })
+    }
+
+    /// Returns a read-only reference to the ring buffer.
+    pub fn buffer(&self) -> &RingBuffer<T> {
+        self.inner.buffer()
+    }
+}
+
+/// A [`Default`]-initialized fixed-size chunk, which advances the write position when dropped.
+///
+/// This is returned from [`ChunkProducer::push_chunk()`].
+///
+/// This `struct` has no inherent methods, but it implements [`DerefMut`],
+/// which provides mutable access to the data as a [`slice`].
+///
+/// For an unsafe alternative that provides an uninitialized chunk, see [`PushChunkUninit`].
+#[derive(Debug, PartialEq, Eq)]
+pub struct PushChunk<'a, T>(PushChunkUninit<'a, T>);
+
+impl<'a, T> From<PushChunkUninit<'a, T>> for PushChunk<'a, T>
+where
+    T: Default,
+{
+    /// Fills all slots with the [`Default`] value.
+    fn from(chunk: PushChunkUninit<'a, T>) -> Self {
+        for i in 0..chunk.len {
+            unsafe {
+                chunk.ptr.add(i).write(Default::default());
+            }
+        }
+        PushChunk(chunk)
+    }
+}
+
+impl<T> Deref for PushChunk<'_, T> {
+    type Target = [T];
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::slice::from_raw_parts(self.0.ptr, self.0.len) }
+    }
+}
+
+impl<T> DerefMut for PushChunk<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { core::slice::from_raw_parts_mut(self.0.ptr, self.0.len) }
+    }
+}
+
+/// An uninitialized fixed-size chunk, which advances the write position when dropped.
+///
+/// This is returned from [`ChunkProducer::push_chunk_uninit()`].
+///
+/// This `struct` has no inherent methods, but it implements [`DerefMut`],
+/// which provides mutable access to the data as a [`slice`] of [`MaybeUninit<T>`].
+///
+/// For a safe alternative that provides [`Default`]-initialized contents, see [`PushChunk`].
+///
+/// # Safety
+///
+/// All slots of the chunk must be initialized before it is dropped
+/// (which might also happen in case of a panic!).
+#[derive(Debug, PartialEq, Eq)]
+pub struct PushChunkUninit<'a, T> {
+    ptr: *mut T,
+    len: usize,
+    producer: &'a mut Producer<T>,
+}
+
+impl<T> Deref for PushChunkUninit<'_, T> {
+    type Target = [MaybeUninit<T>];
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::slice::from_raw_parts(self.ptr as _, self.len) }
+    }
+}
+
+impl<T> DerefMut for PushChunkUninit<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { core::slice::from_raw_parts_mut(self.ptr as _, self.len) }
+    }
+}
+
+impl<T> Drop for PushChunkUninit<'_, T> {
+    /// Advances the write position.
+    ///
+    /// # Safety
+    ///
+    /// All slots must be initialized at this point.
+    fn drop(&mut self) {
+        let tail = self.producer.tail.get();
+        let tail = self.producer.buffer.increment(tail, self.len);
+        self.producer.buffer.tail.store(tail, Ordering::Release);
+        self.producer.tail.set(tail);
+    }
+}
+
+/// The consumer side of a [`RingBuffer`], using fixed-size chunks.
+///
+/// Can be moved between threads,
+/// but references from different threads are not allowed
+/// (i.e. it is [`Send`] but not [`Sync`]).
+///
+/// Can be created with [`RingBuffer::with_chunks(...).of_size(...)`](RingBuffer::with_chunks)
+/// (together with one of its counterparts [`Producer`] or [`ChunkProducer`]).
+///
+/// Fixed-size chunks can be consumed with [`ChunkConsumer::pop_chunk()`]
+/// or they can be read with [`ChunkConsumer::peek_chunk()`] without consuming them.
+///
+/// If not all chunks have the same size, or if individual elements should be consumed,
+/// a [`Consumer`] can be used instead.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ChunkConsumer<T> {
+    inner: Consumer<T>,
+    chunk_size: usize,
+}
+
+unsafe impl<T: Send> Send for ChunkConsumer<T> {}
+
+impl<T> ChunkConsumer<T> {
+    /// Returns a fixed-size chunk for reading, advancing the read position when dropped.
+    ///
+    /// If not enough data for a full chunk is available, an error is returned.
+    ///
+    /// For access to its contents, the returned [`PopChunk<T>`]
+    /// can be (auto-)dereferenced to a [`slice`].
+    ///
+    /// When the returned [`PopChunk<T>`] is dropped, all contained elements are dropped as well
+    /// (if `T` implements [`Drop`]) and the now empty slots are made available for writing.
+    ///
+    /// # Examples
+    ///
+    /// For examples see the documentation of the
+    /// [`fixed_chunks`](crate::fixed_chunks#examples) module.
+    pub fn pop_chunk(&mut self) -> Result<PopChunk<'_, T>, ChunkError> {
+        let head = self.inner.check_chunk(self.chunk_size)?;
+        debug_assert!(self.chunk_size <= self.inner.buffer.capacity - head);
+        Ok(PopChunk {
+            ptr: unsafe { self.inner.buffer.data_ptr.add(head) },
+            len: self.chunk_size,
+            consumer: &mut self.inner,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Returns a fixed-size chunk for reading, not advancing the read position.
+    ///
+    /// If not enough data for a full chunk is available, an error is returned.
+    ///
+    /// # Examples
+    ///
+    /// For examples see the documentation of the
+    /// [`fixed_chunks`](crate::fixed_chunks#examples) module.
+    pub fn peek_chunk(&self) -> Result<&[T], ChunkError> {
+        let head = self.inner.check_chunk(self.chunk_size)?;
+        debug_assert!(self.chunk_size <= self.inner.buffer.capacity - head);
+        Ok(unsafe {
+            core::slice::from_raw_parts(self.inner.buffer.data_ptr.add(head), self.chunk_size)
+        })
+    }
+
+    /// Returns a read-only reference to the ring buffer.
+    pub fn buffer(&self) -> &RingBuffer<T> {
+        self.inner.buffer()
+    }
+}
+
+/// A fixed-size chunk, which drops its contents and advances the read position when dropped.
+///
+/// This is returned from [`ChunkConsumer::pop_chunk()`].
+///
+/// This `struct` has no inherent methods, but it implements [`Deref`],
+/// which provides access to the data as a [`slice`].
+#[derive(Debug, PartialEq, Eq)]
+pub struct PopChunk<'a, T> {
+    ptr: *const T,
+    len: usize,
+    consumer: &'a mut Consumer<T>,
+    // Indicates that items are dropped when the slice goes out of scope.
+    _marker: PhantomData<T>,
+}
+
+impl<T> Deref for PopChunk<'_, T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+impl<T> Drop for PopChunk<'_, T> {
+    /// Drops all contained elements (if `T` implements [`Drop`]) and advances the read position.
+    fn drop(&mut self) {
+        let head = self.consumer.head.get();
+        // Safety: head has not yet been incremented
+        unsafe {
+            let ptr = self.consumer.buffer.slot_ptr(head);
+            for i in 0..self.len {
+                ptr.add(i).drop_in_place();
+            }
+        }
+        let head = self.consumer.buffer.increment(head, self.len);
+        self.consumer.buffer.head.store(head, Ordering::Release);
+        self.consumer.head.set(head);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,158 +39,9 @@
 //! }).join().unwrap();
 //! ```
 //!
-//! Producing and consuming multiple items at once with
-//! [`Producer::write_chunk()`] and [`Consumer::read_chunk()`], respectively.
-//! This example uses a single thread for simplicity, but in a real application,
-//! `producer` and `consumer` would of course live on different threads:
-//!
-//! ```
-//! use rtrb::RingBuffer;
-//!
-//! let (mut producer, mut consumer) = RingBuffer::new(5).split();
-//!
-//! if let Ok(mut chunk) = producer.write_chunk(4) {
-//!     // NB: Don't use `chunk` as the first iterator in zip() if the other one might be shorter!
-//!     for (src, dst) in vec![10, 11, 12].into_iter().zip(&mut chunk) {
-//!         *dst = src;
-//!     }
-//!     // Don't forget to make the written slots available for reading!
-//!     chunk.commit_iterated();
-//!     // Note that we requested 4 slots but we've only written 3!
-//! } else {
-//!     unreachable!();
-//! }
-//!
-//! assert_eq!(producer.slots(), 2);
-//! assert_eq!(consumer.slots(), 3);
-//!
-//! if let Ok(mut chunk) = consumer.read_chunk(2) {
-//!     // NB: Even though we are just reading, `chunk` needs to be mutable for iteration!
-//!     assert_eq!((&mut chunk).collect::<Vec<_>>(), [&10, &11]);
-//!     chunk.commit_iterated(); // Mark the slots as "consumed"
-//!     // chunk.commit_all() would also work here.
-//! } else {
-//!     unreachable!();
-//! }
-//!
-//! // One element is still in the queue:
-//! assert_eq!(consumer.peek(), Ok(&12));
-//!
-//! let data = vec![20, 21, 22, 23];
-//! if let Ok(mut chunk) = producer.write_chunk(4) {
-//!     let (first, second) = chunk.as_mut_slices();
-//!     let mid = first.len();
-//!     first.copy_from_slice(&data[..mid]);
-//!     second.copy_from_slice(&data[mid..]);
-//!     chunk.commit_all();
-//! } else {
-//!     unreachable!();
-//! }
-//!
-//! assert!(producer.is_full());
-//! assert_eq!(consumer.slots(), 5);
-//!
-//! let mut v = Vec::<i32>::with_capacity(5);
-//! if let Ok(chunk) = consumer.read_chunk(5) {
-//!     let (first, second) = chunk.as_slices();
-//!     v.extend(first);
-//!     v.extend(second);
-//!     chunk.commit_all();
-//! } else {
-//!     unreachable!();
-//! }
-//! assert_eq!(v, [12, 20, 21, 22, 23]);
-//! assert!(consumer.is_empty());
-//! ```
-//!
-//! ## Common Access Patterns
-//!
-//! The following examples show the [`Producer`] side;
-//! similar patterns can of course be used with [`Consumer::read_chunk()`] as well.
-//! Furthermore, the examples use [`Producer::write_chunk()`],
-//! which requires the trait bounds `T: Copy + Default`.
-//! If that's too restrictive or if you want to squeeze out the last bit of performance,
-//! you can use [`Producer::write_chunk_uninit()`] instead,
-//! but this will force you to write some `unsafe` code.
-//!
-//! Copy a whole slice of items into the ring buffer, but only if space permits
-//! (if not, the input slice is returned as an error):
-//!
-//! ```
-//! use rtrb::Producer;
-//!
-//! fn push_entire_slice<'a, T>(queue: &mut Producer<T>, slice: &'a [T]) -> Result<(), &'a [T]>
-//! where
-//!     T: Copy + Default,
-//! {
-//!     if let Ok(mut chunk) = queue.write_chunk(slice.len()) {
-//!         let (first, second) = chunk.as_mut_slices();
-//!         let mid = first.len();
-//!         first.copy_from_slice(&slice[..mid]);
-//!         second.copy_from_slice(&slice[mid..]);
-//!         chunk.commit_all();
-//!         Ok(())
-//!     } else {
-//!         Err(slice)
-//!     }
-//! }
-//! ```
-//!
-//! Copy as many items as possible from a given slice, returning the remainder of the slice
-//! (which will be empty if there was space for all items):
-//!
-//! ```
-//! use rtrb::{Producer, ChunkError::TooFewSlots};
-//!
-//! fn push_partial_slice<'a, T>(queue: &mut Producer<T>, slice: &'a [T]) -> &'a [T]
-//! where
-//!     T: Copy + Default,
-//! {
-//!     let mut chunk = match queue.write_chunk(slice.len()) {
-//!         Ok(chunk) => chunk,
-//!         // This is an optional optimization if the queue tends to be full:
-//!         Err(TooFewSlots(0)) => return slice,
-//!         // Remaining slots are returned, this will always succeed:
-//!         Err(TooFewSlots(n)) => queue.write_chunk(n).unwrap(),
-//!     };
-//!     let end = chunk.len();
-//!     let (first, second) = chunk.as_mut_slices();
-//!     let mid = first.len();
-//!     first.copy_from_slice(&slice[..mid]);
-//!     second.copy_from_slice(&slice[mid..end]);
-//!     chunk.commit_all();
-//!     &slice[end..]
-//! }
-//! ```
-//!
-//! Write as many slots as possible, given an iterator
-//! (and return the number of written slots):
-//!
-//! ```
-//! use rtrb::{Producer, ChunkError::TooFewSlots};
-//!
-//! fn push_from_iter<T, I>(queue: &mut Producer<T>, iter: &mut I) -> usize
-//! where
-//!     T: Copy + Default,
-//!     I: Iterator<Item = T>,
-//! {
-//!     let n = match iter.size_hint() {
-//!         (_, None) => queue.slots(),
-//!         (_, Some(n)) => n,
-//!     };
-//!     let mut chunk = match queue.write_chunk(n) {
-//!         Ok(chunk) => chunk,
-//!         // As above, this is an optional optimization:
-//!         Err(TooFewSlots(0)) => return 0,
-//!         // As above, this will always succeed:
-//!         Err(TooFewSlots(n)) => queue.write_chunk(n).unwrap(),
-//!     };
-//!     for (source, target) in iter.zip(&mut chunk) {
-//!         *target = source;
-//!     }
-//!     chunk.commit_iterated()
-//! }
-//! ```
+//! For examples that write multiple items at once with [`Producer::write_chunk()`]
+//! and read multiple items with [`Consumer::read_chunk()`]
+//! see the documentation of the [`chunks`] module.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(rust_2018_idioms)]
@@ -207,6 +58,12 @@ use core::mem::{ManuallyDrop, MaybeUninit};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use cache_padded::CachePadded;
+
+pub mod chunks;
+
+// This is used in the documentation.
+#[allow(unused_imports)]
+use chunks::WriteChunkUninit;
 
 /// A bounded single-producer single-consumer queue.
 ///
@@ -270,27 +127,6 @@ impl<T> RingBuffer<T> {
             capacity,
             _marker: PhantomData,
         }
-    }
-
-    /// Creates a `RingBuffer` with a capacity of `chunks * chunk_size`.
-    ///
-    /// On top of multiplying the two numbers for us,
-    /// this also guarantees that the ring buffer wrap-around happens
-    /// at an integer multiple of `chunk_size`.
-    /// This means that if [`Consumer::read_chunk()`] is used *exclusively* with
-    /// `chunk_size` (and [`Consumer::pop()`] is *not* used in-between),
-    /// the first slice returned from [`ReadChunk::as_slices()`]
-    /// will always contain the entire chunk and the second slice will always be empty.
-    /// Same for [`Producer::write_chunk()`]/[`WriteChunk::as_mut_slices()`] and
-    /// [`Producer::write_chunk_uninit()`]/[`WriteChunkUninit::as_mut_slices()`]
-    /// (as long as [`Producer::push()`] is *not* used in-between).
-    ///
-    /// If above conditions have been violated, the wrap-around guarantee can be restored
-    /// wit [`reset()`](RingBuffer::reset).
-    pub fn with_chunks(chunks: usize, chunk_size: usize) -> RingBuffer<T> {
-        // NB: Currently, there is nothing special to do here, but in the future
-        //     it might be necessary to take some steps to guarantee the promised behavior.
-        Self::new(chunks * chunk_size)
     }
 
     /// Splits the `RingBuffer` into [`Producer`] and [`Consumer`].
@@ -497,13 +333,12 @@ impl<T> Eq for RingBuffer<T> {}
 /// Can only be created with [`RingBuffer::split()`]
 /// (together with its counterpart, the [`Consumer`]).
 ///
-/// # Examples
+/// Individual elements can be moved into the ring buffer with [`Producer::push()`],
+/// multiple elements at once can be written with [`Producer::write_chunk()`]
+/// and [`Producer::write_chunk_uninit()`].
 ///
-/// ```
-/// use rtrb::RingBuffer;
-///
-/// let (producer, consumer) = RingBuffer::<f32>::new(1000).split();
-/// ```
+/// The number of free slots currently available for writing can be obtained with
+/// [`Producer::slots()`].
 #[derive(Debug)]
 pub struct Producer<T> {
     /// A reference to the ring buffer.
@@ -553,85 +388,10 @@ impl<T> Producer<T> {
         }
     }
 
-    /// Returns `n` slots (initially containing their [`Default`] value) for writing.
-    ///
-    /// If not enough slots are available, an error
-    /// (containing the number of available slots) is returned.
-    ///
-    /// The elements can be accessed with [`WriteChunk::as_mut_slices()`] or
-    /// by iterating over (a `&mut` to) the [`WriteChunk`].
-    ///
-    /// The provided slots are *not* automatically made available
-    /// to be read by the [`Consumer`].
-    /// This has to be explicitly done by calling [`WriteChunk::commit()`],
-    /// [`WriteChunk::commit_iterated()`] or [`WriteChunk::commit_all()`].
-    ///
-    /// The type parameter `T` has a trait bound of [`Copy`],
-    /// which makes sure that no destructors are called at any time
-    /// (because it implies [`!Drop`](Drop)).
-    ///
-    /// For an unsafe alternative that has no restrictions on `T`,
-    /// see [`Producer::write_chunk_uninit()`].
-    ///
-    /// # Examples
-    ///
-    /// See the [crate-level documentation](crate#examples) for examples.
-    pub fn write_chunk(&mut self, n: usize) -> Result<WriteChunk<'_, T>, ChunkError>
-    where
-        T: Copy + Default,
-    {
-        self.write_chunk_uninit(n).map(WriteChunk::from)
-    }
-
-    /// Returns `n` (uninitialized) slots for writing.
-    ///
-    /// If not enough slots are available, an error
-    /// (containing the number of available slots) is returned.
-    ///
-    /// The elements can be accessed with [`WriteChunkUninit::as_mut_slices()`] or
-    /// by iterating over (a `&mut` to) the [`WriteChunkUninit`].
-    ///
-    /// The provided slots are *not* automatically made available
-    /// to be read by the [`Consumer`].
-    /// This has to be explicitly done by calling [`WriteChunkUninit::commit()`],
-    /// [`WriteChunkUninit::commit_iterated()`] or
-    /// [`WriteChunkUninit::commit_all()`].
-    ///
-    /// # Safety
-    ///
-    /// This function itself is safe, but accessing the returned slots might not be,
-    /// as well as invoking some methods of [`WriteChunkUninit`].
-    ///
-    /// For a safe alternative that provides [`Default`]-initialized slots,
-    /// see [`Producer::write_chunk()`].
-    pub fn write_chunk_uninit(&mut self, n: usize) -> Result<WriteChunkUninit<'_, T>, ChunkError> {
-        let tail = self.tail.get();
-
-        // Check if the queue has *possibly* not enough slots.
-        if self.buffer.capacity - self.buffer.distance(self.head.get(), tail) < n {
-            // Refresh the head ...
-            let head = self.buffer.head.load(Ordering::Acquire);
-            self.head.set(head);
-
-            // ... and check if there *really* are not enough slots.
-            let slots = self.buffer.capacity - self.buffer.distance(head, tail);
-            if slots < n {
-                return Err(ChunkError::TooFewSlots(slots));
-            }
-        }
-        let tail = self.buffer.collapse_position(tail);
-        let first_len = n.min(self.buffer.capacity - tail);
-        Ok(WriteChunkUninit {
-            first_ptr: unsafe { self.buffer.data_ptr.add(tail) },
-            first_len,
-            second_ptr: self.buffer.data_ptr,
-            second_len: n - first_len,
-            producer: self,
-            iterated: 0,
-        })
-    }
-
     /// Returns the number of slots available for writing.
+    ///
+    /// The number of available slots might increase at any time
+    /// if the corresponding [`Consumer`] is consuming items in another thread.
     ///
     /// To check for a single available slot,
     /// using [`Producer::is_full()`] is often quicker
@@ -653,6 +413,9 @@ impl<T> Producer<T> {
     }
 
     /// Returns `true` if there are no slots available for writing.
+    ///
+    /// A full ring buffer might cease to be full at any time
+    /// if the corresponding [`Consumer`] is consuming items in another thread.
     ///
     /// # Examples
     ///
@@ -703,13 +466,11 @@ impl<T> Producer<T> {
 /// Can only be created with [`RingBuffer::split()`]
 /// (together with its counterpart, the [`Producer`]).
 ///
-/// # Examples
+/// Individual elements can be moved out of the ring buffer with [`Consumer::pop()`],
+/// multiple elements at once can be read with [`Consumer::read_chunk()`].
 ///
-/// ```
-/// use rtrb::RingBuffer;
-///
-/// let (producer, consumer) = RingBuffer::<f32>::new(1000).split();
-/// ```
+/// The number of free slots currently available for reading can be obtained with
+/// [`Consumer::slots()`].
 #[derive(Debug, PartialEq, Eq)]
 pub struct Consumer<T> {
     /// A reference to the ring buffer.
@@ -791,99 +552,10 @@ impl<T> Consumer<T> {
         }
     }
 
-    /// Returns `n` slots for reading.
-    ///
-    /// If not enough slots are available, an error
-    /// (containing the number of available slots) is returned.
-    ///
-    /// The elements can be accessed with [`ReadChunk::as_slices()`] or
-    /// by iterating over (a `&mut` to) the [`ReadChunk`].
-    ///
-    /// The provided slots are *not* automatically made available
-    /// to be written again by the [`Producer`].
-    /// This has to be explicitly done by calling [`ReadChunk::commit()`],
-    /// [`ReadChunk::commit_iterated()`] or [`ReadChunk::commit_all()`].
-    /// You can "peek" at the contained values by simply
-    /// not calling any of the "commit" methods.
-    ///
-    /// # Examples
-    ///
-    /// Items are dropped when [`ReadChunk::commit()`], [`ReadChunk::commit_iterated()`]
-    /// or [`ReadChunk::commit_all()`] is called
-    /// (which is only relevant if `T` implements [`Drop`]).
-    ///
-    /// ```
-    /// use rtrb::RingBuffer;
-    ///
-    /// // Static variable to count all drop() invocations
-    /// static mut DROP_COUNT: i32 = 0;
-    /// #[derive(Debug)]
-    /// struct Thing;
-    /// impl Drop for Thing {
-    ///     fn drop(&mut self) { unsafe { DROP_COUNT += 1; } }
-    /// }
-    ///
-    /// // Scope to limit lifetime of ring buffer
-    /// {
-    ///     let (mut p, mut c) = RingBuffer::new(2).split();
-    ///
-    ///     assert!(p.push(Thing).is_ok()); // 1
-    ///     assert!(p.push(Thing).is_ok()); // 2
-    ///     if let Ok(thing) = c.pop() {
-    ///         // "thing" has been *moved* out of the queue but not yet dropped
-    ///         assert_eq!(unsafe { DROP_COUNT }, 0);
-    ///     } else {
-    ///         unreachable!();
-    ///     }
-    ///     // First Thing has been dropped when "thing" went out of scope:
-    ///     assert_eq!(unsafe { DROP_COUNT }, 1);
-    ///     assert!(p.push(Thing).is_ok()); // 3
-    ///
-    ///     if let Ok(chunk) = c.read_chunk(2) {
-    ///         assert_eq!(chunk.len(), 2);
-    ///         assert_eq!(unsafe { DROP_COUNT }, 1);
-    ///         chunk.commit(1); // Drops only one of the two Things
-    ///         assert_eq!(unsafe { DROP_COUNT }, 2);
-    ///     } else {
-    ///         unreachable!();
-    ///     }
-    ///     // The last Thing is still in the queue ...
-    ///     assert_eq!(unsafe { DROP_COUNT }, 2);
-    /// }
-    /// // ... and it is dropped when the ring buffer goes out of scope:
-    /// assert_eq!(unsafe { DROP_COUNT }, 3);
-    /// ```
-    ///
-    /// See the [crate-level documentation](crate#examples) for more examples.
-    pub fn read_chunk(&mut self, n: usize) -> Result<ReadChunk<'_, T>, ChunkError> {
-        let head = self.head.get();
-
-        // Check if the queue has *possibly* not enough slots.
-        if self.buffer.distance(head, self.tail.get()) < n {
-            // Refresh the tail ...
-            let tail = self.buffer.tail.load(Ordering::Acquire);
-            self.tail.set(tail);
-
-            // ... and check if there *really* are not enough slots.
-            let slots = self.buffer.distance(head, tail);
-            if slots < n {
-                return Err(ChunkError::TooFewSlots(slots));
-            }
-        }
-
-        let head = self.buffer.collapse_position(head);
-        let first_len = n.min(self.buffer.capacity - head);
-        Ok(ReadChunk {
-            first_ptr: unsafe { self.buffer.data_ptr.add(head) },
-            first_len,
-            second_ptr: self.buffer.data_ptr,
-            second_len: n - first_len,
-            consumer: self,
-            iterated: 0,
-        })
-    }
-
     /// Returns the number of slots available for reading.
+    ///
+    /// The number of available slots might increase at any time
+    /// if the corresponding [`Producer`] is producing items in another thread.
     ///
     /// To check for a single available slot,
     /// using [`Consumer::is_empty()`] is often quicker
@@ -905,6 +577,9 @@ impl<T> Consumer<T> {
     }
 
     /// Returns `true` if there are no slots available for reading.
+    ///
+    /// An empty ring buffer might cease to be empty at any time
+    /// if the corresponding [`Producer`] is producing items in another thread.
     ///
     /// # Examples
     ///
@@ -946,237 +621,6 @@ impl<T> Consumer<T> {
     }
 }
 
-/// Structure for writing into multiple ([`Default`]-initialized) slots in one go.
-///
-/// This is returned from [`Producer::write_chunk()`].
-///
-/// For an unsafe alternative that provides uninitialized slots,
-/// see [`WriteChunkUninit`].
-///
-/// The slots (which initially contain [`Default`] values) can be accessed with
-/// [`as_mut_slices()`](WriteChunk::as_mut_slices)
-/// or by iteration, which yields mutable references (in other words: `&mut T`).
-/// A mutable reference (`&mut`) to the `WriteChunk`
-/// should be used to iterate over it.
-/// Each slot can only be iterated once and the number of iterations is tracked.
-///
-/// After writing, the provided slots are *not* automatically made available
-/// to be read by the [`Consumer`].
-/// If desired, this has to be explicitly done by calling
-/// [`commit()`](WriteChunk::commit),
-/// [`commit_iterated()`](WriteChunk::commit_iterated) or
-/// [`commit_all()`](WriteChunk::commit_all).
-#[derive(Debug)]
-pub struct WriteChunk<'a, T>(WriteChunkUninit<'a, T>);
-
-impl<'a, T> From<WriteChunkUninit<'a, T>> for WriteChunk<'a, T>
-where
-    T: Copy + Default,
-{
-    /// Fills all slots with the [`Default`] value.
-    fn from(chunk: WriteChunkUninit<'a, T>) -> Self {
-        for i in 0..chunk.first_len {
-            unsafe {
-                chunk.first_ptr.add(i).write(Default::default());
-            }
-        }
-        for i in 0..chunk.second_len {
-            unsafe {
-                chunk.second_ptr.add(i).write(Default::default());
-            }
-        }
-        WriteChunk(chunk)
-    }
-}
-
-impl<T> WriteChunk<'_, T>
-where
-    T: Copy + Default,
-{
-    /// Returns two slices for writing to the requested slots.
-    ///
-    /// All slots are initially filled with their [`Default`] value.
-    ///
-    /// The first slice can only be empty if `0` slots have been requested.
-    /// If the first slice contains all requested slots, the second one is empty.
-    ///
-    /// See [`RingBuffer::with_chunks()`] for a way to make sure
-    /// that the second slice is always empty.
-    pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
-        // Safety: All slots have been initialized in From::from().
-        unsafe {
-            (
-                core::slice::from_raw_parts_mut(self.0.first_ptr, self.0.first_len),
-                core::slice::from_raw_parts_mut(self.0.second_ptr, self.0.second_len),
-            )
-        }
-    }
-
-    /// Makes the first `n` slots of the chunk available for reading.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n` is greater than the number of slots in the chunk.
-    pub fn commit(self, n: usize) {
-        // Safety: All slots have been initialized in From::from() and there are no destructors.
-        unsafe { self.0.commit(n) }
-    }
-
-    /// Returns the number of iterated slots and makes them available for reading.
-    pub fn commit_iterated(self) -> usize {
-        // Safety: All slots have been initialized in From::from() and there are no destructors.
-        unsafe { self.0.commit_iterated() }
-    }
-
-    /// Makes the whole chunk available for reading.
-    pub fn commit_all(self) {
-        // Safety: All slots have been initialized in From::from().
-        unsafe { self.0.commit_all() }
-    }
-
-    /// Returns the number of slots in the chunk.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns `true` if the chunk contains no slots.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl<'a, T> Iterator for WriteChunk<'a, T>
-where
-    T: Copy + Default,
-{
-    type Item = &'a mut T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|item| {
-            // Safety: All slots have been initialized in From::from().
-            unsafe { &mut *item.as_mut_ptr() }
-        })
-    }
-}
-
-/// Structure for writing into multiple (uninitialized) slots in one go.
-///
-/// This is returned from [`Producer::write_chunk_uninit()`].
-///
-/// For a safe alternative that provides [`Default`]-initialized slots, see [`WriteChunk`].
-///
-/// The slots can be accessed with
-/// [`as_mut_slices()`](WriteChunkUninit::as_mut_slices)
-/// or by iteration, which yields mutable references to possibly uninitialized data
-/// (in other words: `&mut MaybeUninit<T>`).
-/// A mutable reference (`&mut`) to the `WriteChunkUninit`
-/// should be used to iterate over it.
-/// Each slot can only be iterated once and the number of iterations is tracked.
-///
-/// After writing, the provided slots are *not* automatically made available
-/// to be read by the [`Consumer`].
-/// If desired, this has to be explicitly done by calling
-/// [`commit()`](WriteChunkUninit::commit),
-/// [`commit_iterated()`](WriteChunkUninit::commit_iterated) or
-/// [`commit_all()`](WriteChunkUninit::commit_all).
-#[derive(Debug)]
-pub struct WriteChunkUninit<'a, T> {
-    first_ptr: *mut T,
-    first_len: usize,
-    second_ptr: *mut T,
-    second_len: usize,
-    producer: &'a Producer<T>,
-    iterated: usize,
-}
-
-impl<T> WriteChunkUninit<'_, T> {
-    /// Returns two slices for writing to the requested slots.
-    ///
-    /// The first slice can only be empty if `0` slots have been requested.
-    /// If the first slice contains all requested slots, the second one is empty.
-    ///
-    /// See [`RingBuffer::with_chunks()`] for a way to make sure
-    /// that the second slice is always empty.
-    ///
-    /// The extension trait [`CopyToUninit`] can be used to safely copy data into those slices.
-    pub fn as_mut_slices(&mut self) -> (&mut [MaybeUninit<T>], &mut [MaybeUninit<T>]) {
-        unsafe {
-            (
-                core::slice::from_raw_parts_mut(self.first_ptr as *mut _, self.first_len),
-                core::slice::from_raw_parts_mut(self.second_ptr as *mut _, self.second_len),
-            )
-        }
-    }
-
-    /// Makes the first `n` slots of the chunk available for reading.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n` is greater than the number of slots in the chunk.
-    ///
-    /// # Safety
-    ///
-    /// The user must make sure that the first `n` elements
-    /// (and not more, in case `T` implements [`Drop`]) have been initialized.
-    pub unsafe fn commit(self, n: usize) {
-        assert!(n <= self.len(), "cannot commit more than chunk size");
-        self.commit_unchecked(n);
-    }
-
-    /// Returns the number of iterated slots and makes them available for reading.
-    ///
-    /// # Safety
-    ///
-    /// The user must make sure that all iterated elements have been initialized.
-    pub unsafe fn commit_iterated(self) -> usize {
-        let slots = self.iterated;
-        self.commit_unchecked(slots)
-    }
-
-    /// Makes the whole chunk available for reading.
-    ///
-    /// # Safety
-    ///
-    /// The user must make sure that all elements have been initialized.
-    pub unsafe fn commit_all(self) {
-        let slots = self.len();
-        self.commit_unchecked(slots);
-    }
-
-    unsafe fn commit_unchecked(self, n: usize) -> usize {
-        let tail = self.producer.buffer.increment(self.producer.tail.get(), n);
-        self.producer.buffer.tail.store(tail, Ordering::Release);
-        self.producer.tail.set(tail);
-        n
-    }
-
-    /// Returns the number of slots in the chunk.
-    pub fn len(&self) -> usize {
-        self.first_len + self.second_len
-    }
-
-    /// Returns `true` if the chunk contains no slots.
-    pub fn is_empty(&self) -> bool {
-        self.first_len == 0
-    }
-}
-
-impl<'a, T> Iterator for WriteChunkUninit<'a, T> {
-    type Item = &'a mut MaybeUninit<T>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let ptr = if self.iterated < self.first_len {
-            unsafe { self.first_ptr.add(self.iterated) }
-        } else if self.iterated < self.first_len + self.second_len {
-            unsafe { self.second_ptr.add(self.iterated - self.first_len) }
-        } else {
-            return None;
-        };
-        self.iterated += 1;
-        Some(unsafe { &mut *(ptr as *mut _) })
-    }
-}
-
 /// Extension trait used to provide a [`copy_to_uninit()`](CopyToUninit::copy_to_uninit)
 /// method on built-in slices.
 ///
@@ -1207,166 +651,6 @@ impl<T: Copy> CopyToUninit<T> for [T] {
         );
         let dst_ptr = dst.as_mut_ptr() as *mut _;
         unsafe { self.as_ptr().copy_to_nonoverlapping(dst_ptr, self.len()) };
-    }
-}
-
-/// Structure for reading from multiple slots in one go.
-///
-/// This is returned from [`Consumer::read_chunk()`].
-///
-/// The slots can be accessed with [`as_slices()`](ReadChunk::as_slices)
-/// or by iteration.
-/// Even though iterating yields immutable references (`&T`),
-/// a mutable reference (`&mut`) to the `ReadChunk` should be used to iterate over it.
-/// Each slot can only be iterated once and the number of iterations is tracked.
-///
-/// After reading, the provided slots are *not* automatically made available
-/// to be written again by the [`Producer`].
-/// If desired, this has to be explicitly done by calling [`commit()`](ReadChunk::commit),
-/// [`commit_iterated()`](ReadChunk::commit_iterated) or [`commit_all()`](ReadChunk::commit_all).
-/// Note that this runs the destructor of the committed items (if `T` implements [`Drop`]).
-#[derive(Debug, PartialEq, Eq)]
-pub struct ReadChunk<'a, T> {
-    first_ptr: *const T,
-    first_len: usize,
-    second_ptr: *const T,
-    second_len: usize,
-    consumer: &'a mut Consumer<T>,
-    iterated: usize,
-}
-
-impl<T> ReadChunk<'_, T> {
-    /// Returns two slices for reading from the requested slots.
-    ///
-    /// The first slice can only be empty if `0` slots have been requested.
-    /// If the first slice contains all requested slots, the second one is empty.
-    ///
-    /// See [`RingBuffer::with_chunks()`] for a way to make sure
-    /// that the second slice is always empty.
-    pub fn as_slices(&self) -> (&[T], &[T]) {
-        (
-            unsafe { core::slice::from_raw_parts(self.first_ptr, self.first_len) },
-            unsafe { core::slice::from_raw_parts(self.second_ptr, self.second_len) },
-        )
-    }
-
-    /// Drops the first `n` slots of the chunk, making the space available for writing again.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n` is greater than the number of slots in the chunk.
-    pub fn commit(self, n: usize) {
-        assert!(n <= self.len(), "cannot commit more than chunk size");
-        unsafe { self.commit_unchecked(n) };
-    }
-
-    /// Drops all slots that have been iterated, making the space available for writing again.
-    ///
-    /// Returns the number of iterated slots.
-    pub fn commit_iterated(self) -> usize {
-        let slots = self.iterated;
-        unsafe { self.commit_unchecked(slots) }
-    }
-
-    /// Drops all slots of the chunk, making the space available for writing again.
-    pub fn commit_all(self) {
-        let slots = self.len();
-        unsafe { self.commit_unchecked(slots) };
-    }
-
-    unsafe fn commit_unchecked(self, n: usize) -> usize {
-        let head = self.consumer.head.get();
-        // Safety: head has not yet been incremented
-        let ptr = self.consumer.buffer.slot_ptr(head);
-        let first_len = self.first_len.min(n);
-        for i in 0..first_len {
-            ptr.add(i).drop_in_place();
-        }
-        let ptr = self.consumer.buffer.data_ptr;
-        let second_len = self.second_len.min(n - first_len);
-        for i in 0..second_len {
-            ptr.add(i).drop_in_place();
-        }
-        let head = self.consumer.buffer.increment(head, n);
-        self.consumer.buffer.head.store(head, Ordering::Release);
-        self.consumer.head.set(head);
-        n
-    }
-
-    /// Returns the number of slots in the chunk.
-    pub fn len(&self) -> usize {
-        self.first_len + self.second_len
-    }
-
-    /// Returns `true` if the chunk contains no slots.
-    pub fn is_empty(&self) -> bool {
-        self.first_len == 0
-    }
-}
-
-impl<'a, T> Iterator for ReadChunk<'a, T> {
-    type Item = &'a T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let ptr = if self.iterated < self.first_len {
-            unsafe { self.first_ptr.add(self.iterated) }
-        } else if self.iterated < self.first_len + self.second_len {
-            unsafe { self.second_ptr.add(self.iterated - self.first_len) }
-        } else {
-            return None;
-        };
-        self.iterated += 1;
-        Some(unsafe { &*ptr })
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::io::Write for Producer<u8> {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        use ChunkError::TooFewSlots;
-        let mut chunk = match self.write_chunk_uninit(buf.len()) {
-            Ok(chunk) => chunk,
-            Err(TooFewSlots(0)) => return Err(std::io::ErrorKind::WouldBlock.into()),
-            Err(TooFewSlots(n)) => self.write_chunk_uninit(n).unwrap(),
-        };
-        let end = chunk.len();
-        let (first, second) = chunk.as_mut_slices();
-        let mid = first.len();
-        // NB: If buf.is_empty(), chunk will be empty as well and the following are no-ops:
-        buf[..mid].copy_to_uninit(first);
-        buf[mid..end].copy_to_uninit(second);
-        // Safety: All slots have been initialized
-        unsafe {
-            chunk.commit_all();
-        }
-        Ok(end)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        // Nothing to do here.
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::io::Read for Consumer<u8> {
-    #[inline]
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        use ChunkError::TooFewSlots;
-        let chunk = match self.read_chunk(buf.len()) {
-            Ok(chunk) => chunk,
-            Err(TooFewSlots(0)) => return Err(std::io::ErrorKind::WouldBlock.into()),
-            Err(TooFewSlots(n)) => self.read_chunk(n).unwrap(),
-        };
-        let (first, second) = chunk.as_slices();
-        let mid = first.len();
-        let end = chunk.len();
-        // NB: If buf.is_empty(), chunk will be empty as well and the following are no-ops:
-        buf[..mid].copy_from_slice(first);
-        buf[mid..end].copy_from_slice(second);
-        chunk.commit_all();
-        Ok(end)
     }
 }
 
@@ -1428,29 +712,6 @@ impl<T> fmt::Display for PushError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PushError::Full(_) => "full ring buffer".fmt(f),
-        }
-    }
-}
-
-/// Error type for [`Consumer::read_chunk()`], [`Producer::write_chunk()`]
-/// and [`Producer::write_chunk_uninit()`].
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ChunkError {
-    /// Fewer than the requested number of slots were available.
-    ///
-    /// Contains the number of slots that were available.
-    TooFewSlots(usize),
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for ChunkError {}
-
-impl fmt::Display for ChunkError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ChunkError::TooFewSlots(n) => {
-                alloc::format!("only {} slots available in ring buffer", n).fmt(f)
-            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! A realtime-safe single-producer single-consumer (SPSC) ring buffer.
 //!
 //! A [`RingBuffer`] consists of two parts:
-//! a [`Producer`] for writing into the ring buffer and
-//! a [`Consumer`] for reading from the ring buffer.
+//! a [`Producer`] (or [`ChunkProducer`]) for writing into the ring buffer and
+//! a [`Consumer`] (or [`ChunkConsumer`]) for reading from the ring buffer.
 //!
 //! A fixed-capacity buffer is allocated on construction.
 //! After that, no more memory is allocated (unless the type `T` does that internally).
@@ -26,7 +26,7 @@
 //! ```
 //! use rtrb::{RingBuffer, PushError, PopError};
 //!
-//! let (mut producer, mut consumer) = RingBuffer::new(2).split();
+//! let (mut producer, mut consumer) = RingBuffer::new(2);
 //!
 //! assert_eq!(producer.push(10), Ok(()));
 //! assert_eq!(producer.push(20), Ok(()));
@@ -40,8 +40,12 @@
 //! ```
 //!
 //! For examples that write multiple items at once with [`Producer::write_chunk()`]
-//! and read multiple items with [`Consumer::read_chunk()`]
-//! see the documentation of the [`chunks`] module.
+//! and/or read multiple items at once with [`Consumer::read_chunk()`]
+//! see the documentation of the [`chunks#examples`] module.
+//!
+//! For examples that write fixed-size chunks with [`ChunkProducer::push_chunk()`]
+//! and/or read fixed-size chunks with [`ChunkConsumer::pop_chunk()`]
+//! see the documentation of the [`fixed_chunks#examples`] module.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(rust_2018_idioms)]
@@ -60,15 +64,22 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use cache_padded::CachePadded;
 
 pub mod chunks;
+pub mod fixed_chunks;
 
 // This is used in the documentation.
 #[allow(unused_imports)]
 use chunks::WriteChunkUninit;
+#[allow(unused_imports)]
+use fixed_chunks::{ChunkConsumer, ChunkProducer};
 
-/// A bounded single-producer single-consumer queue.
+/// A bounded single-producer single-consumer (SPSC) queue.
 ///
 /// Elements can be written with a [`Producer`] and read with a [`Consumer`],
-/// both of which can be obtained with [`RingBuffer::split()`].
+/// both of which can be obtained with [`RingBuffer::new()`].
+///
+/// Alternatively, fixed-size chunks can be written with a [`ChunkProducer`] and/or
+/// read with a [`ChunkConsumer`], which can be obtained with
+/// [`RingBuffer::with_chunks(...).of_size(...)`](RingBuffer::with_chunks).
 ///
 /// *See also the [crate-level documentation](crate).*
 #[derive(Debug)]
@@ -94,20 +105,17 @@ pub struct RingBuffer<T> {
 }
 
 impl<T> RingBuffer<T> {
-    /// Creates a `RingBuffer` with the given `capacity`.
+    /// Creates a `RingBuffer` with the given `capacity` and returns [`Producer`] and [`Consumer`].
     ///
-    /// The returned `RingBuffer` is typically immediately split into
-    /// the [`Producer`] and the [`Consumer`] side by [`split()`](RingBuffer::split).
-    ///
-    /// If you want guaranteed wrap-around behavior,
-    /// use [`with_chunks()`](RingBuffer::with_chunks).
+    /// If fixed-size chunks are desired, a [`ChunkProducer`] and/or [`ChunkConsumer`] can be
+    /// created with [`RingBuffer::with_chunks(...).of_size(...)`](RingBuffer::with_chunks).
     ///
     /// # Examples
     ///
     /// ```
     /// use rtrb::RingBuffer;
     ///
-    /// let rb = RingBuffer::<f32>::new(100);
+    /// let (producer, consumer) = RingBuffer::<f32>::new(100);
     /// ```
     ///
     /// Specifying an explicit type with the [turbofish](https://turbo.fish/)
@@ -116,30 +124,18 @@ impl<T> RingBuffer<T> {
     /// ```
     /// use rtrb::RingBuffer;
     ///
-    /// let (mut producer, consumer) = RingBuffer::new(100).split();
+    /// let (mut producer, consumer) = RingBuffer::new(100);
     /// assert_eq!(producer.push(0.0f32), Ok(()));
     /// ```
-    pub fn new(capacity: usize) -> RingBuffer<T> {
-        RingBuffer {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(capacity: usize) -> (Producer<T>, Consumer<T>) {
+        let buffer = Arc::new(RingBuffer {
             head: CachePadded::new(AtomicUsize::new(0)),
             tail: CachePadded::new(AtomicUsize::new(0)),
             data_ptr: ManuallyDrop::new(Vec::with_capacity(capacity)).as_mut_ptr(),
             capacity,
             _marker: PhantomData,
-        }
-    }
-
-    /// Splits the `RingBuffer` into [`Producer`] and [`Consumer`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rtrb::RingBuffer;
-    ///
-    /// let (producer, consumer) = RingBuffer::<f32>::new(100).split();
-    /// ```
-    pub fn split(self) -> (Producer<T>, Consumer<T>) {
-        let buffer = Arc::new(self);
+        });
         let p = Producer {
             buffer: buffer.clone(),
             head: Cell::new(0),
@@ -153,73 +149,16 @@ impl<T> RingBuffer<T> {
         (p, c)
     }
 
-    /// Resets a ring buffer.
-    ///
-    /// This drops all elements that are currently in the queue
-    /// (running their destructors if `T` implements [`Drop`]) and
-    /// resets the internal read and write positions to the beginning of the buffer.
-    ///
-    /// This also resets the guarantees given by [`with_chunks()`](RingBuffer::with_chunks).
-    ///
-    /// Exclusive access to both [`Producer`] and [`Consumer`] is needed for this operation.
-    /// They can be moved between threads, for example, with a `RingBuffer<Producer<T>>`
-    /// and a `RingBuffer<Consumer<T>>`, respectively.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the `producer` and `consumer` do not originate from the same `RingBuffer`.
+    /// Returns the capacity of the ring buffer.
     ///
     /// # Examples
     ///
     /// ```
     /// use rtrb::RingBuffer;
     ///
-    /// let (mut p, mut c) = RingBuffer::new(2).split();
-    ///
-    /// p = std::thread::spawn(move || {
-    ///     assert_eq!(p.push(10), Ok(()));
-    ///     p
-    /// }).join().unwrap();
-    ///
-    /// RingBuffer::reset(&mut p, &mut c);
-    ///
-    /// // The full capacity is now available for writing:
-    /// if let Ok(mut chunk) = p.write_chunk(p.buffer().capacity()) {
-    ///     let (first, second) = chunk.as_mut_slices();
-    ///     // The first slice is now guaranteed to span the whole buffer:
-    ///     first[0] = 20;
-    ///     first[1] = 30;
-    ///     assert!(second.is_empty());
-    ///     chunk.commit_all();
-    /// } else {
-    ///     unreachable!();
-    /// }
-    /// ```
-    pub fn reset(producer: &mut Producer<T>, consumer: &mut Consumer<T>) {
-        assert!(
-            Arc::ptr_eq(&producer.buffer, &consumer.buffer),
-            "producer and consumer not from the same ring buffer"
-        );
-        consumer.read_chunk(consumer.slots()).unwrap().commit_all();
-        assert_eq!(
-            producer.buffer.head.swap(0, Ordering::Relaxed),
-            producer.buffer.tail.swap(0, Ordering::Relaxed)
-        );
-        producer.head.set(0);
-        producer.tail.set(0);
-        consumer.head.set(0);
-        consumer.tail.set(0);
-    }
-
-    /// Returns the capacity of the queue.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rtrb::RingBuffer;
-    ///
-    /// let rb = RingBuffer::<f32>::new(100);
-    /// assert_eq!(rb.capacity(), 100);
+    /// let (producer, consumer) = RingBuffer::<f32>::new(100);
+    /// assert_eq!(producer.buffer().capacity(), 100);
+    /// assert_eq!(consumer.buffer().capacity(), 100);
     /// ```
     pub fn capacity(&self) -> usize {
         self.capacity
@@ -309,12 +248,11 @@ impl<T> PartialEq for RingBuffer<T> {
     /// ```
     /// use rtrb::RingBuffer;
     ///
-    /// let (p, c) = RingBuffer::<f32>::new(1000).split();
+    /// let (p, c) = RingBuffer::<f32>::new(1000);
     /// assert_eq!(p.buffer(), c.buffer());
     ///
-    /// let rb1 = RingBuffer::<f32>::new(1000);
-    /// let rb2 = RingBuffer::<f32>::new(1000);
-    /// assert_ne!(rb1, rb2);
+    /// let (other_p, _) = RingBuffer::<f32>::new(1000);
+    /// assert_ne!(p.buffer(), other_p.buffer());
     /// ```
     fn eq(&self, other: &Self) -> bool {
         // There can never be multiple instances with the same `data_ptr`.
@@ -330,8 +268,9 @@ impl<T> Eq for RingBuffer<T> {}
 /// but references from different threads are not allowed
 /// (i.e. it is [`Send`] but not [`Sync`]).
 ///
-/// Can only be created with [`RingBuffer::split()`]
-/// (together with its counterpart, the [`Consumer`]).
+/// Can be created with [`RingBuffer::new()`] (together with its counterpart, the [`Consumer`]),
+/// or with [`RingBuffer::with_chunks(...).of_size(...)`](RingBuffer::with_chunks)
+/// (together with its other counterpart, the [`ChunkConsumer`]).
 ///
 /// Individual elements can be moved into the ring buffer with [`Producer::push()`],
 /// multiple elements at once can be written with [`Producer::write_chunk()`]
@@ -339,7 +278,9 @@ impl<T> Eq for RingBuffer<T> {}
 ///
 /// The number of free slots currently available for writing can be obtained with
 /// [`Producer::slots()`].
-#[derive(Debug)]
+///
+/// If all chunks have the same size, a [`ChunkProducer`] can be used instead.
+#[derive(Debug, PartialEq, Eq)]
 pub struct Producer<T> {
     /// A reference to the ring buffer.
     buffer: Arc<RingBuffer<T>>,
@@ -369,7 +310,7 @@ impl<T> Producer<T> {
     /// ```
     /// use rtrb::{RingBuffer, PushError};
     ///
-    /// let (mut p, c) = RingBuffer::new(1).split();
+    /// let (mut p, c) = RingBuffer::new(1);
     ///
     /// assert_eq!(p.push(10), Ok(()));
     /// assert_eq!(p.push(20), Err(PushError::Full(20)));
@@ -402,7 +343,7 @@ impl<T> Producer<T> {
     /// ```
     /// use rtrb::RingBuffer;
     ///
-    /// let (p, c) = RingBuffer::<f32>::new(1024).split();
+    /// let (p, c) = RingBuffer::<f32>::new(1024);
     ///
     /// assert_eq!(p.slots(), 1024);
     /// ```
@@ -422,7 +363,7 @@ impl<T> Producer<T> {
     /// ```
     /// use rtrb::RingBuffer;
     ///
-    /// let (p, c) = RingBuffer::<f32>::new(1).split();
+    /// let (p, c) = RingBuffer::<f32>::new(1);
     ///
     /// assert!(!p.is_full());
     /// ```
@@ -437,7 +378,7 @@ impl<T> Producer<T> {
 
     /// Get the tail position for writing the next slot, if available.
     ///
-    /// This is a strict subset of the functionality implemented in write_chunk_uninit().
+    /// This is a strict subset of the functionality implemented in Producer::check_chunk().
     /// For performance, this special case is immplemented separately.
     fn next_tail(&self) -> Option<usize> {
         let tail = self.tail.get();
@@ -463,14 +404,17 @@ impl<T> Producer<T> {
 /// but references from different threads are not allowed
 /// (i.e. it is [`Send`] but not [`Sync`]).
 ///
-/// Can only be created with [`RingBuffer::split()`]
-/// (together with its counterpart, the [`Producer`]).
+/// Can be created with [`RingBuffer::new()`] (together with its counterpart, the [`Producer`]),
+/// or with [`RingBuffer::with_chunks(...).of_size(...)`](RingBuffer::with_chunks)
+/// (together with its other counterpart, the [`ChunkProducer`]).
 ///
 /// Individual elements can be moved out of the ring buffer with [`Consumer::pop()`],
 /// multiple elements at once can be read with [`Consumer::read_chunk()`].
 ///
 /// The number of free slots currently available for reading can be obtained with
 /// [`Consumer::slots()`].
+///
+/// If all chunks have the same size, a [`ChunkConsumer`] can be used instead.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Consumer<T> {
     /// A reference to the ring buffer.
@@ -501,7 +445,7 @@ impl<T> Consumer<T> {
     /// ```
     /// use rtrb::{PopError, RingBuffer};
     ///
-    /// let (mut p, mut c) = RingBuffer::new(1).split();
+    /// let (mut p, mut c) = RingBuffer::new(1);
     ///
     /// assert_eq!(p.push(10), Ok(()));
     /// assert_eq!(c.pop(), Ok(10));
@@ -512,7 +456,7 @@ impl<T> Consumer<T> {
     ///
     /// ```
     /// # use rtrb::RingBuffer;
-    /// # let (mut p, mut c) = RingBuffer::new(1).split();
+    /// # let (mut p, mut c) = RingBuffer::new(1);
     /// assert_eq!(p.push(20), Ok(()));
     /// assert_eq!(c.pop().ok(), Some(20));
     /// ```
@@ -537,7 +481,7 @@ impl<T> Consumer<T> {
     /// ```
     /// use rtrb::{PeekError, RingBuffer};
     ///
-    /// let (mut p, c) = RingBuffer::new(1).split();
+    /// let (mut p, c) = RingBuffer::new(1);
     ///
     /// assert_eq!(c.peek(), Err(PeekError::Empty));
     /// assert_eq!(p.push(10), Ok(()));
@@ -566,7 +510,7 @@ impl<T> Consumer<T> {
     /// ```
     /// use rtrb::RingBuffer;
     ///
-    /// let (p, c) = RingBuffer::<f32>::new(1024).split();
+    /// let (p, c) = RingBuffer::<f32>::new(1024);
     ///
     /// assert_eq!(c.slots(), 0);
     /// ```
@@ -586,7 +530,7 @@ impl<T> Consumer<T> {
     /// ```
     /// use rtrb::RingBuffer;
     ///
-    /// let (p, c) = RingBuffer::<f32>::new(1).split();
+    /// let (p, c) = RingBuffer::<f32>::new(1);
     ///
     /// assert!(c.is_empty());
     /// ```
@@ -601,7 +545,7 @@ impl<T> Consumer<T> {
 
     /// Get the head position for reading the next slot, if available.
     ///
-    /// This is a strict subset of the functionality implemented in read_chunk().
+    /// This is a strict subset of the functionality implemented in Consumer::check_chunk().
     /// For performance, this special case is immplemented separately.
     fn next_head(&self) -> Option<usize> {
         let head = self.head.get();
@@ -625,7 +569,7 @@ impl<T> Consumer<T> {
 /// method on built-in slices.
 ///
 /// This can be used to safely copy data to the slices returned from
-/// [`WriteChunkUninit::as_mut_slices()`].
+/// [`WriteChunkUninit::as_mut_slices()`] and [`ChunkProducer::push_chunk_uninit()`].
 ///
 /// To use this, the trait has to be brought into scope, e.g. with:
 ///

--- a/tests/push_and_pop.rs
+++ b/tests/push_and_pop.rs
@@ -6,7 +6,7 @@ use rtrb::{chunks::ChunkError, RingBuffer};
 
 #[test]
 fn smoke() {
-    let (mut p, mut c) = RingBuffer::new(1).split();
+    let (mut p, mut c) = RingBuffer::new(1);
 
     p.push(7).unwrap();
     assert_eq!(c.pop(), Ok(7));
@@ -19,7 +19,7 @@ fn smoke() {
 #[test]
 fn capacity() {
     for i in 1..10 {
-        let (p, c) = RingBuffer::<i32>::new(i).split();
+        let (p, c) = RingBuffer::<i32>::new(i);
         assert_eq!(p.buffer().capacity(), i);
         assert_eq!(c.buffer().capacity(), i);
     }
@@ -27,7 +27,7 @@ fn capacity() {
 
 #[test]
 fn zero_capacity() {
-    let (mut p, mut c) = RingBuffer::<i32>::new(0).split();
+    let (mut p, mut c) = RingBuffer::<i32>::new(0);
 
     assert_eq!(p.slots(), 0);
     assert_eq!(c.slots(), 0);
@@ -65,7 +65,7 @@ fn zero_sized_type() {
     struct ZeroSized;
     assert_eq!(std::mem::size_of::<ZeroSized>(), 0);
 
-    let (mut p, mut c) = RingBuffer::new(1).split();
+    let (mut p, mut c) = RingBuffer::new(1);
     assert_eq!(p.buffer().capacity(), 1);
     assert_eq!(p.slots(), 1);
     assert_eq!(c.slots(), 0);
@@ -82,7 +82,7 @@ fn zero_sized_type() {
 #[test]
 fn parallel() {
     const COUNT: usize = 100_000;
-    let (mut p, mut c) = RingBuffer::new(3).split();
+    let (mut p, mut c) = RingBuffer::new(3);
     let pop_thread = std::thread::spawn(move || {
         for i in 0..COUNT {
             loop {
@@ -125,7 +125,7 @@ fn drops() {
         let additional = rng.gen_range(0, 50);
 
         DROPS.store(0, Ordering::SeqCst);
-        let (mut p, mut c) = RingBuffer::new(50).split();
+        let (mut p, mut c) = RingBuffer::new(50);
         let pop_thread = std::thread::spawn(move || {
             for _ in 0..steps {
                 while c.pop().is_err() {}

--- a/tests/push_and_pop.rs
+++ b/tests/push_and_pop.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rand::{thread_rng, Rng};
 
-use rtrb::{ChunkError, RingBuffer};
+use rtrb::{chunks::ChunkError, RingBuffer};
 
 #[test]
 fn smoke() {

--- a/tests/write_and_read.rs
+++ b/tests/write_and_read.rs
@@ -6,7 +6,7 @@ use rtrb::RingBuffer;
 
 #[test]
 fn write_and_read() {
-    let (mut p, mut c) = RingBuffer::new(2).split();
+    let (mut p, mut c) = RingBuffer::new(2);
     assert_eq!(p.write(&[10, 11]).unwrap(), 2);
 
     let mut buf = [0];
@@ -32,20 +32,20 @@ fn write_and_read() {
 
 #[test]
 fn write_empty_buf() {
-    let (mut p, _c) = RingBuffer::new(2).split();
+    let (mut p, _c) = RingBuffer::new(2);
     assert_eq!(p.write(&[]).unwrap(), 0);
 }
 
 #[test]
 fn read_empty_buf() {
-    let (mut p, mut c) = RingBuffer::new(2).split();
+    let (mut p, mut c) = RingBuffer::new(2);
     assert_eq!(p.push(99), Ok(()));
     assert_eq!(c.read(&mut []).unwrap(), 0);
 }
 
 #[test]
 fn write_error() {
-    let (mut p, _c) = RingBuffer::new(1).split();
+    let (mut p, _c) = RingBuffer::new(1);
     assert_eq!(p.push(10), Ok(()));
     assert_eq!(
         p.write(&[99]).unwrap_err().kind(),
@@ -55,7 +55,7 @@ fn write_error() {
 
 #[test]
 fn read_error() {
-    let (_p, mut c) = RingBuffer::new(1).split();
+    let (_p, mut c) = RingBuffer::new(1);
     let mut buf = [0];
     assert_eq!(
         c.read(&mut buf).unwrap_err().kind(),


### PR DESCRIPTION
Closes  #43.

Previously, when using fixed-size chunks (using the `with_chunks()` constructor), the second slice was always empty. However, the compiler didn't know about this.

This PR introduces new `structs` that know that they are fixed-size chunks and therefore, the second slice (that's empty anyway) isn't needed anymore.

Non-fixed-size chunks still work the same as before, containing two slices.

This PR does several things:

* move the previous chunk functionality to the `chunks` sub-module, hopefully making the documentation better structured
* create a new `fixed_chunks` sub-module
* get rid of the `.split()` method, producer and consumer are now directly created by `RingBuffer::new(...)`
* get rid of the previous `RingBuffer::with_chunks(..., ...)` constructor and replace it with a combined builder-like `RingBuffer::with_chunks(...).of_size(...)` that returns a producer-constructor pair
* get rid of the `Copy` trait bound on the uninitialized API

As always, the HTML documentation can be created locally with `cargo doc`.

Rendered HTML files as ZIP: https://github.com/mgeier/rtrb/suites/2660989728/artifacts/58566186