### PR TITLE
Simplify API

### DIFF
--- a/benches/single_thread_single_byte.rs
+++ b/benches/single_thread_single_byte.rs
@@ -36,7 +36,7 @@ pub fn criterion_benchmark(criterion: &mut criterion::Criterion) {
         v.pop().unwrap()
     });
 
-    let (mut p, mut c) = RingBuffer::<u8>::new(1).split();
+    let (mut p, mut c) = RingBuffer::<u8>::new(1);
 
     add_function(&mut group, "1-push-pop", |i| {
         p.push(i).unwrap();

--- a/benches/single_thread_two_bytes.rs
+++ b/benches/single_thread_two_bytes.rs
@@ -41,7 +41,7 @@ pub fn criterion_benchmark(criterion: &mut criterion::Criterion) {
     group.throughput(criterion::Throughput::Bytes(2));
     group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
 
-    let (mut p, mut c) = RingBuffer::<u8>::new(3).split();
+    let (mut p, mut c) = RingBuffer::<u8>::new(3);
 
     add_function(&mut group, "1-push-pop", |data| {
         let mut result = [0; 2];

--- a/benches/single_thread_with_chunks.rs
+++ b/benches/single_thread_with_chunks.rs
@@ -36,7 +36,7 @@ pub fn criterion_benchmark(criterion: &mut criterion::Criterion) {
     group.throughput(criterion::Throughput::Bytes(CHUNK_SIZE as u64));
     group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
 
-    let (mut p, mut c) = RingBuffer::<u8>::with_chunks(1000, CHUNK_SIZE).split();
+    let (mut p, mut c) = RingBuffer::<u8>::new(1000 * CHUNK_SIZE).split();
 
     add_function(&mut group, "1-pop", |data| {
         let mut result = [0; CHUNK_SIZE];

--- a/benches/single_thread_with_chunks.rs
+++ b/benches/single_thread_with_chunks.rs
@@ -36,7 +36,7 @@ pub fn criterion_benchmark(criterion: &mut criterion::Criterion) {
     group.throughput(criterion::Throughput::Bytes(CHUNK_SIZE as u64));
     group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
 
-    let (mut p, mut c) = RingBuffer::<u8>::new(1000 * CHUNK_SIZE).split();
+    let (mut p, mut c) = RingBuffer::<u8>::new(1000 * CHUNK_SIZE);
 
     add_function(&mut group, "1-pop", |data| {
         let mut result = [0; CHUNK_SIZE];

--- a/benches/two_threads.rs
+++ b/benches/two_threads.rs
@@ -91,7 +91,7 @@ fn criterion_benchmark(criterion: &mut criterion::Criterion) {
     add_function(
         &mut group,
         "",
-        |capacity| RingBuffer::new(capacity).split(),
+        RingBuffer::new,
         |p, i| p.push(i).is_ok(),
         |c| c.pop().ok(),
     );

--- a/benches/two_threads.rs
+++ b/benches/two_threads.rs
@@ -14,9 +14,9 @@ pub fn add_function<P, C, Create, Push, Pop, M>(
 ) where
     P: Send + 'static,
     C: Send + 'static,
-    Create: Fn(usize) -> (P, C) + Copy,
+    Create: Fn(usize) -> (P, C),
     Push: Fn(&mut P, u8) -> bool + Send + Copy + 'static,
-    Pop: Fn(&mut C) -> Option<u8> + Send + Copy + 'static,
+    Pop: Fn(&mut C) -> Option<u8> + Send + 'static,
     M: criterion::measurement::Measurement<Value = std::time::Duration>,
 {
     // Just a quick check if the ring buffer works as expected:

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -1,0 +1,778 @@
+//! Writing and reading multiple items at once into and from a [`RingBuffer`].
+//!
+//! Multiple items can be written at once by using [`Producer::write_chunk()`]
+//! or its `unsafe` (but probably slightly faster) cousin [`Producer::write_chunk_uninit()`].
+//!
+//! Multiple items can be read at once with [`Consumer::read_chunk()`].
+//!
+//! # Examples
+//!
+//! Producing and consuming multiple items at once with
+//! [`Producer::write_chunk()`] and [`Consumer::read_chunk()`], respectively.
+//! This example uses a single thread for simplicity, but in a real application,
+//! `producer` and `consumer` would of course live on different threads:
+//!
+//! ```
+//! use rtrb::RingBuffer;
+//!
+//! let (mut producer, mut consumer) = RingBuffer::new(5).split();
+//!
+//! if let Ok(mut chunk) = producer.write_chunk(4) {
+//!     // NB: Don't use `chunk` as the first iterator in zip() if the other one might be shorter!
+//!     for (src, dst) in vec![10, 11, 12].into_iter().zip(&mut chunk) {
+//!         *dst = src;
+//!     }
+//!     // Don't forget to make the written slots available for reading!
+//!     chunk.commit_iterated();
+//!     // Note that we requested 4 slots but we've only written 3!
+//! } else {
+//!     unreachable!();
+//! }
+//!
+//! assert_eq!(producer.slots(), 2);
+//! assert_eq!(consumer.slots(), 3);
+//!
+//! if let Ok(mut chunk) = consumer.read_chunk(2) {
+//!     // NB: Even though we are just reading, `chunk` needs to be mutable for iteration!
+//!     assert_eq!((&mut chunk).collect::<Vec<_>>(), [&10, &11]);
+//!     chunk.commit_iterated(); // Mark the slots as "consumed"
+//!     // chunk.commit_all() would also work here.
+//! } else {
+//!     unreachable!();
+//! }
+//!
+//! // One element is still in the queue:
+//! assert_eq!(consumer.peek(), Ok(&12));
+//!
+//! let data = vec![20, 21, 22, 23];
+//! if let Ok(mut chunk) = producer.write_chunk(4) {
+//!     let (first, second) = chunk.as_mut_slices();
+//!     let mid = first.len();
+//!     first.copy_from_slice(&data[..mid]);
+//!     second.copy_from_slice(&data[mid..]);
+//!     chunk.commit_all();
+//! } else {
+//!     unreachable!();
+//! }
+//!
+//! assert!(producer.is_full());
+//! assert_eq!(consumer.slots(), 5);
+//!
+//! let mut v = Vec::<i32>::with_capacity(5);
+//! if let Ok(chunk) = consumer.read_chunk(5) {
+//!     let (first, second) = chunk.as_slices();
+//!     v.extend(first);
+//!     v.extend(second);
+//!     chunk.commit_all();
+//! } else {
+//!     unreachable!();
+//! }
+//! assert_eq!(v, [12, 20, 21, 22, 23]);
+//! assert!(consumer.is_empty());
+//! ```
+//!
+//! ## Common Access Patterns
+//!
+//! The following examples show the [`Producer`] side;
+//! similar patterns can of course be used with [`Consumer::read_chunk()`] as well.
+//! Furthermore, the examples use [`Producer::write_chunk()`],
+//! which requires the trait bounds `T: Copy + Default`.
+//! If that's too restrictive or if you want to squeeze out the last bit of performance,
+//! you can use [`Producer::write_chunk_uninit()`] instead,
+//! but this will force you to write some `unsafe` code.
+//!
+//! Copy a whole slice of items into the ring buffer, but only if space permits
+//! (if not, the input slice is returned as an error):
+//!
+//! ```
+//! use rtrb::Producer;
+//!
+//! fn push_entire_slice<'a, T>(queue: &mut Producer<T>, slice: &'a [T]) -> Result<(), &'a [T]>
+//! where
+//!     T: Copy + Default,
+//! {
+//!     if let Ok(mut chunk) = queue.write_chunk(slice.len()) {
+//!         let (first, second) = chunk.as_mut_slices();
+//!         let mid = first.len();
+//!         first.copy_from_slice(&slice[..mid]);
+//!         second.copy_from_slice(&slice[mid..]);
+//!         chunk.commit_all();
+//!         Ok(())
+//!     } else {
+//!         Err(slice)
+//!     }
+//! }
+//! ```
+//!
+//! Copy as many items as possible from a given slice, returning the remainder of the slice
+//! (which will be empty if there was space for all items):
+//!
+//! ```
+//! use rtrb::{Producer, chunks::ChunkError::TooFewSlots};
+//!
+//! fn push_partial_slice<'a, T>(queue: &mut Producer<T>, slice: &'a [T]) -> &'a [T]
+//! where
+//!     T: Copy + Default,
+//! {
+//!     let mut chunk = match queue.write_chunk(slice.len()) {
+//!         Ok(chunk) => chunk,
+//!         // This is an optional optimization if the queue tends to be full:
+//!         Err(TooFewSlots(0)) => return slice,
+//!         // Remaining slots are returned, this will always succeed:
+//!         Err(TooFewSlots(n)) => queue.write_chunk(n).unwrap(),
+//!     };
+//!     let end = chunk.len();
+//!     let (first, second) = chunk.as_mut_slices();
+//!     let mid = first.len();
+//!     first.copy_from_slice(&slice[..mid]);
+//!     second.copy_from_slice(&slice[mid..end]);
+//!     chunk.commit_all();
+//!     &slice[end..]
+//! }
+//! ```
+//!
+//! Write as many slots as possible, given an iterator
+//! (and return the number of written slots):
+//!
+//! ```
+//! use rtrb::{Producer, chunks::ChunkError::TooFewSlots};
+//!
+//! fn push_from_iter<T, I>(queue: &mut Producer<T>, iter: &mut I) -> usize
+//! where
+//!     T: Copy + Default,
+//!     I: Iterator<Item = T>,
+//! {
+//!     let n = match iter.size_hint() {
+//!         (_, None) => queue.slots(),
+//!         (_, Some(n)) => n,
+//!     };
+//!     let mut chunk = match queue.write_chunk(n) {
+//!         Ok(chunk) => chunk,
+//!         // As above, this is an optional optimization:
+//!         Err(TooFewSlots(0)) => return 0,
+//!         // As above, this will always succeed:
+//!         Err(TooFewSlots(n)) => queue.write_chunk(n).unwrap(),
+//!     };
+//!     for (source, target) in iter.zip(&mut chunk) {
+//!         *target = source;
+//!     }
+//!     chunk.commit_iterated()
+//! }
+//! ```
+
+use core::fmt;
+use core::mem::MaybeUninit;
+use core::sync::atomic::Ordering;
+
+use crate::{Consumer, CopyToUninit, Producer, RingBuffer};
+
+impl<T> RingBuffer<T> {
+    /// Creates a `RingBuffer` with a capacity of `chunks * chunk_size`.
+    ///
+    /// On top of multiplying the two numbers for us,
+    /// this also guarantees that the ring buffer wrap-around happens
+    /// at an integer multiple of `chunk_size`.
+    /// This means that if [`Consumer::read_chunk()`] is used *exclusively* with
+    /// `chunk_size` (and [`Consumer::pop()`] is *not* used in-between),
+    /// the first slice returned from [`ReadChunk::as_slices()`]
+    /// will always contain the entire chunk and the second slice will always be empty.
+    /// Same for [`Producer::write_chunk()`]/[`WriteChunk::as_mut_slices()`] and
+    /// [`Producer::write_chunk_uninit()`]/[`WriteChunkUninit::as_mut_slices()`]
+    /// (as long as [`Producer::push()`] is *not* used in-between).
+    ///
+    /// If above conditions have been violated, the wrap-around guarantee can be restored
+    /// wit [`reset()`](RingBuffer::reset).
+    pub fn with_chunks(chunks: usize, chunk_size: usize) -> RingBuffer<T> {
+        // NB: Currently, there is nothing special to do here, but in the future
+        //     it might be necessary to take some steps to guarantee the promised behavior.
+        Self::new(chunks * chunk_size)
+    }
+}
+
+impl<T> Producer<T> {
+    /// Returns `n` slots (initially containing their [`Default`] value) for writing.
+    ///
+    /// If not enough slots are available, an error
+    /// (containing the number of available slots) is returned.
+    ///
+    /// The elements can be accessed with [`WriteChunk::as_mut_slices()`] or
+    /// by iterating over (a `&mut` to) the [`WriteChunk`].
+    ///
+    /// The provided slots are *not* automatically made available
+    /// to be read by the [`Consumer`].
+    /// This has to be explicitly done by calling [`WriteChunk::commit()`],
+    /// [`WriteChunk::commit_iterated()`] or [`WriteChunk::commit_all()`].
+    ///
+    /// The type parameter `T` has a trait bound of [`Copy`],
+    /// which makes sure that no destructors are called at any time
+    /// (because it implies [`!Drop`](Drop)).
+    ///
+    /// For an unsafe alternative that has no restrictions on `T`,
+    /// see [`Producer::write_chunk_uninit()`].
+    ///
+    /// # Examples
+    ///
+    /// See the documentation of the [`chunks`](crate::chunks#examples) module for more examples.
+    pub fn write_chunk(&mut self, n: usize) -> Result<WriteChunk<'_, T>, ChunkError>
+    where
+        T: Copy + Default,
+    {
+        self.write_chunk_uninit(n).map(WriteChunk::from)
+    }
+
+    /// Returns `n` (uninitialized) slots for writing.
+    ///
+    /// If not enough slots are available, an error
+    /// (containing the number of available slots) is returned.
+    ///
+    /// The elements can be accessed with [`WriteChunkUninit::as_mut_slices()`] or
+    /// by iterating over (a `&mut` to) the [`WriteChunkUninit`].
+    ///
+    /// The provided slots are *not* automatically made available
+    /// to be read by the [`Consumer`].
+    /// This has to be explicitly done by calling [`WriteChunkUninit::commit()`],
+    /// [`WriteChunkUninit::commit_iterated()`] or
+    /// [`WriteChunkUninit::commit_all()`].
+    ///
+    /// # Safety
+    ///
+    /// This function itself is safe, but accessing the returned slots might not be,
+    /// as well as invoking some methods of [`WriteChunkUninit`].
+    ///
+    /// For a safe alternative that provides [`Default`]-initialized slots,
+    /// see [`Producer::write_chunk()`].
+    pub fn write_chunk_uninit(&mut self, n: usize) -> Result<WriteChunkUninit<'_, T>, ChunkError> {
+        let tail = self.tail.get();
+
+        // Check if the queue has *possibly* not enough slots.
+        if self.buffer.capacity - self.buffer.distance(self.head.get(), tail) < n {
+            // Refresh the head ...
+            let head = self.buffer.head.load(Ordering::Acquire);
+            self.head.set(head);
+
+            // ... and check if there *really* are not enough slots.
+            let slots = self.buffer.capacity - self.buffer.distance(head, tail);
+            if slots < n {
+                return Err(ChunkError::TooFewSlots(slots));
+            }
+        }
+        let tail = self.buffer.collapse_position(tail);
+        let first_len = n.min(self.buffer.capacity - tail);
+        Ok(WriteChunkUninit {
+            first_ptr: unsafe { self.buffer.data_ptr.add(tail) },
+            first_len,
+            second_ptr: self.buffer.data_ptr,
+            second_len: n - first_len,
+            producer: self,
+            iterated: 0,
+        })
+    }
+}
+
+impl<T> Consumer<T> {
+    /// Returns `n` slots for reading.
+    ///
+    /// If not enough slots are available, an error
+    /// (containing the number of available slots) is returned.
+    ///
+    /// The elements can be accessed with [`ReadChunk::as_slices()`] or
+    /// by iterating over (a `&mut` to) the [`ReadChunk`].
+    ///
+    /// The provided slots are *not* automatically made available
+    /// to be written again by the [`Producer`].
+    /// This has to be explicitly done by calling [`ReadChunk::commit()`],
+    /// [`ReadChunk::commit_iterated()`] or [`ReadChunk::commit_all()`].
+    /// You can "peek" at the contained values by simply
+    /// not calling any of the "commit" methods.
+    ///
+    /// # Examples
+    ///
+    /// Items are dropped when [`ReadChunk::commit()`], [`ReadChunk::commit_iterated()`]
+    /// or [`ReadChunk::commit_all()`] is called
+    /// (which is only relevant if `T` implements [`Drop`]).
+    ///
+    /// ```
+    /// use rtrb::RingBuffer;
+    ///
+    /// // Static variable to count all drop() invocations
+    /// static mut DROP_COUNT: i32 = 0;
+    /// #[derive(Debug)]
+    /// struct Thing;
+    /// impl Drop for Thing {
+    ///     fn drop(&mut self) { unsafe { DROP_COUNT += 1; } }
+    /// }
+    ///
+    /// // Scope to limit lifetime of ring buffer
+    /// {
+    ///     let (mut p, mut c) = RingBuffer::new(2).split();
+    ///
+    ///     assert!(p.push(Thing).is_ok()); // 1
+    ///     assert!(p.push(Thing).is_ok()); // 2
+    ///     if let Ok(thing) = c.pop() {
+    ///         // "thing" has been *moved* out of the queue but not yet dropped
+    ///         assert_eq!(unsafe { DROP_COUNT }, 0);
+    ///     } else {
+    ///         unreachable!();
+    ///     }
+    ///     // First Thing has been dropped when "thing" went out of scope:
+    ///     assert_eq!(unsafe { DROP_COUNT }, 1);
+    ///     assert!(p.push(Thing).is_ok()); // 3
+    ///
+    ///     if let Ok(chunk) = c.read_chunk(2) {
+    ///         assert_eq!(chunk.len(), 2);
+    ///         assert_eq!(unsafe { DROP_COUNT }, 1);
+    ///         chunk.commit(1); // Drops only one of the two Things
+    ///         assert_eq!(unsafe { DROP_COUNT }, 2);
+    ///     } else {
+    ///         unreachable!();
+    ///     }
+    ///     // The last Thing is still in the queue ...
+    ///     assert_eq!(unsafe { DROP_COUNT }, 2);
+    /// }
+    /// // ... and it is dropped when the ring buffer goes out of scope:
+    /// assert_eq!(unsafe { DROP_COUNT }, 3);
+    /// ```
+    ///
+    /// See the documentation of the [`chunks`](crate::chunks#examples) module for more examples.
+    pub fn read_chunk(&mut self, n: usize) -> Result<ReadChunk<'_, T>, ChunkError> {
+        let head = self.head.get();
+
+        // Check if the queue has *possibly* not enough slots.
+        if self.buffer.distance(head, self.tail.get()) < n {
+            // Refresh the tail ...
+            let tail = self.buffer.tail.load(Ordering::Acquire);
+            self.tail.set(tail);
+
+            // ... and check if there *really* are not enough slots.
+            let slots = self.buffer.distance(head, tail);
+            if slots < n {
+                return Err(ChunkError::TooFewSlots(slots));
+            }
+        }
+
+        let head = self.buffer.collapse_position(head);
+        let first_len = n.min(self.buffer.capacity - head);
+        Ok(ReadChunk {
+            first_ptr: unsafe { self.buffer.data_ptr.add(head) },
+            first_len,
+            second_ptr: self.buffer.data_ptr,
+            second_len: n - first_len,
+            consumer: self,
+            iterated: 0,
+        })
+    }
+}
+
+/// Structure for writing into multiple ([`Default`]-initialized) slots in one go.
+///
+/// This is returned from [`Producer::write_chunk()`].
+///
+/// For an unsafe alternative that provides uninitialized slots,
+/// see [`WriteChunkUninit`].
+///
+/// The slots (which initially contain [`Default`] values) can be accessed with
+/// [`as_mut_slices()`](WriteChunk::as_mut_slices)
+/// or by iteration, which yields mutable references (in other words: `&mut T`).
+/// A mutable reference (`&mut`) to the `WriteChunk`
+/// should be used to iterate over it.
+/// Each slot can only be iterated once and the number of iterations is tracked.
+///
+/// After writing, the provided slots are *not* automatically made available
+/// to be read by the [`Consumer`].
+/// If desired, this has to be explicitly done by calling
+/// [`commit()`](WriteChunk::commit),
+/// [`commit_iterated()`](WriteChunk::commit_iterated) or
+/// [`commit_all()`](WriteChunk::commit_all).
+#[derive(Debug)]
+pub struct WriteChunk<'a, T>(WriteChunkUninit<'a, T>);
+
+impl<'a, T> From<WriteChunkUninit<'a, T>> for WriteChunk<'a, T>
+where
+    T: Copy + Default,
+{
+    /// Fills all slots with the [`Default`] value.
+    fn from(chunk: WriteChunkUninit<'a, T>) -> Self {
+        for i in 0..chunk.first_len {
+            unsafe {
+                chunk.first_ptr.add(i).write(Default::default());
+            }
+        }
+        for i in 0..chunk.second_len {
+            unsafe {
+                chunk.second_ptr.add(i).write(Default::default());
+            }
+        }
+        WriteChunk(chunk)
+    }
+}
+
+impl<T> WriteChunk<'_, T>
+where
+    T: Copy + Default,
+{
+    /// Returns two slices for writing to the requested slots.
+    ///
+    /// All slots are initially filled with their [`Default`] value.
+    ///
+    /// The first slice can only be empty if `0` slots have been requested.
+    /// If the first slice contains all requested slots, the second one is empty.
+    ///
+    /// See [`RingBuffer::with_chunks()`] for a way to make sure
+    /// that the second slice is always empty.
+    pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
+        // Safety: All slots have been initialized in From::from().
+        unsafe {
+            (
+                core::slice::from_raw_parts_mut(self.0.first_ptr, self.0.first_len),
+                core::slice::from_raw_parts_mut(self.0.second_ptr, self.0.second_len),
+            )
+        }
+    }
+
+    /// Makes the first `n` slots of the chunk available for reading.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is greater than the number of slots in the chunk.
+    pub fn commit(self, n: usize) {
+        // Safety: All slots have been initialized in From::from() and there are no destructors.
+        unsafe { self.0.commit(n) }
+    }
+
+    /// Returns the number of iterated slots and makes them available for reading.
+    pub fn commit_iterated(self) -> usize {
+        // Safety: All slots have been initialized in From::from() and there are no destructors.
+        unsafe { self.0.commit_iterated() }
+    }
+
+    /// Makes the whole chunk available for reading.
+    pub fn commit_all(self) {
+        // Safety: All slots have been initialized in From::from().
+        unsafe { self.0.commit_all() }
+    }
+
+    /// Returns the number of slots in the chunk.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the chunk contains no slots.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl<'a, T> Iterator for WriteChunk<'a, T>
+where
+    T: Copy + Default,
+{
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|item| {
+            // Safety: All slots have been initialized in From::from().
+            unsafe { &mut *item.as_mut_ptr() }
+        })
+    }
+}
+
+/// Structure for writing into multiple (uninitialized) slots in one go.
+///
+/// This is returned from [`Producer::write_chunk_uninit()`].
+///
+/// For a safe alternative that provides [`Default`]-initialized slots, see [`WriteChunk`].
+///
+/// The slots can be accessed with
+/// [`as_mut_slices()`](WriteChunkUninit::as_mut_slices)
+/// or by iteration, which yields mutable references to possibly uninitialized data
+/// (in other words: `&mut MaybeUninit<T>`).
+/// A mutable reference (`&mut`) to the `WriteChunkUninit`
+/// should be used to iterate over it.
+/// Each slot can only be iterated once and the number of iterations is tracked.
+///
+/// After writing, the provided slots are *not* automatically made available
+/// to be read by the [`Consumer`].
+/// If desired, this has to be explicitly done by calling
+/// [`commit()`](WriteChunkUninit::commit),
+/// [`commit_iterated()`](WriteChunkUninit::commit_iterated) or
+/// [`commit_all()`](WriteChunkUninit::commit_all).
+#[derive(Debug)]
+pub struct WriteChunkUninit<'a, T> {
+    first_ptr: *mut T,
+    first_len: usize,
+    second_ptr: *mut T,
+    second_len: usize,
+    producer: &'a Producer<T>,
+    iterated: usize,
+}
+
+impl<T> WriteChunkUninit<'_, T> {
+    /// Returns two slices for writing to the requested slots.
+    ///
+    /// The first slice can only be empty if `0` slots have been requested.
+    /// If the first slice contains all requested slots, the second one is empty.
+    ///
+    /// See [`RingBuffer::with_chunks()`] for a way to make sure
+    /// that the second slice is always empty.
+    ///
+    /// The extension trait [`CopyToUninit`] can be used to safely copy data into those slices.
+    pub fn as_mut_slices(&mut self) -> (&mut [MaybeUninit<T>], &mut [MaybeUninit<T>]) {
+        unsafe {
+            (
+                core::slice::from_raw_parts_mut(self.first_ptr as *mut _, self.first_len),
+                core::slice::from_raw_parts_mut(self.second_ptr as *mut _, self.second_len),
+            )
+        }
+    }
+
+    /// Makes the first `n` slots of the chunk available for reading.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is greater than the number of slots in the chunk.
+    ///
+    /// # Safety
+    ///
+    /// The user must make sure that the first `n` elements
+    /// (and not more, in case `T` implements [`Drop`]) have been initialized.
+    pub unsafe fn commit(self, n: usize) {
+        assert!(n <= self.len(), "cannot commit more than chunk size");
+        self.commit_unchecked(n);
+    }
+
+    /// Returns the number of iterated slots and makes them available for reading.
+    ///
+    /// # Safety
+    ///
+    /// The user must make sure that all iterated elements have been initialized.
+    pub unsafe fn commit_iterated(self) -> usize {
+        let slots = self.iterated;
+        self.commit_unchecked(slots)
+    }
+
+    /// Makes the whole chunk available for reading.
+    ///
+    /// # Safety
+    ///
+    /// The user must make sure that all elements have been initialized.
+    pub unsafe fn commit_all(self) {
+        let slots = self.len();
+        self.commit_unchecked(slots);
+    }
+
+    unsafe fn commit_unchecked(self, n: usize) -> usize {
+        let tail = self.producer.buffer.increment(self.producer.tail.get(), n);
+        self.producer.buffer.tail.store(tail, Ordering::Release);
+        self.producer.tail.set(tail);
+        n
+    }
+
+    /// Returns the number of slots in the chunk.
+    pub fn len(&self) -> usize {
+        self.first_len + self.second_len
+    }
+
+    /// Returns `true` if the chunk contains no slots.
+    pub fn is_empty(&self) -> bool {
+        self.first_len == 0
+    }
+}
+
+impl<'a, T> Iterator for WriteChunkUninit<'a, T> {
+    type Item = &'a mut MaybeUninit<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let ptr = if self.iterated < self.first_len {
+            unsafe { self.first_ptr.add(self.iterated) }
+        } else if self.iterated < self.first_len + self.second_len {
+            unsafe { self.second_ptr.add(self.iterated - self.first_len) }
+        } else {
+            return None;
+        };
+        self.iterated += 1;
+        Some(unsafe { &mut *(ptr as *mut _) })
+    }
+}
+
+/// Structure for reading from multiple slots in one go.
+///
+/// This is returned from [`Consumer::read_chunk()`].
+///
+/// The slots can be accessed with [`as_slices()`](ReadChunk::as_slices)
+/// or by iteration.
+/// Even though iterating yields immutable references (`&T`),
+/// a mutable reference (`&mut`) to the `ReadChunk` should be used to iterate over it.
+/// Each slot can only be iterated once and the number of iterations is tracked.
+///
+/// After reading, the provided slots are *not* automatically made available
+/// to be written again by the [`Producer`].
+/// If desired, this has to be explicitly done by calling [`commit()`](ReadChunk::commit),
+/// [`commit_iterated()`](ReadChunk::commit_iterated) or [`commit_all()`](ReadChunk::commit_all).
+/// Note that this runs the destructor of the committed items (if `T` implements [`Drop`]).
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReadChunk<'a, T> {
+    first_ptr: *const T,
+    first_len: usize,
+    second_ptr: *const T,
+    second_len: usize,
+    consumer: &'a mut Consumer<T>,
+    iterated: usize,
+}
+
+impl<T> ReadChunk<'_, T> {
+    /// Returns two slices for reading from the requested slots.
+    ///
+    /// The first slice can only be empty if `0` slots have been requested.
+    /// If the first slice contains all requested slots, the second one is empty.
+    ///
+    /// See [`RingBuffer::with_chunks()`] for a way to make sure
+    /// that the second slice is always empty.
+    pub fn as_slices(&self) -> (&[T], &[T]) {
+        (
+            unsafe { core::slice::from_raw_parts(self.first_ptr, self.first_len) },
+            unsafe { core::slice::from_raw_parts(self.second_ptr, self.second_len) },
+        )
+    }
+
+    /// Drops the first `n` slots of the chunk, making the space available for writing again.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is greater than the number of slots in the chunk.
+    pub fn commit(self, n: usize) {
+        assert!(n <= self.len(), "cannot commit more than chunk size");
+        unsafe { self.commit_unchecked(n) };
+    }
+
+    /// Drops all slots that have been iterated, making the space available for writing again.
+    ///
+    /// Returns the number of iterated slots.
+    pub fn commit_iterated(self) -> usize {
+        let slots = self.iterated;
+        unsafe { self.commit_unchecked(slots) }
+    }
+
+    /// Drops all slots of the chunk, making the space available for writing again.
+    pub fn commit_all(self) {
+        let slots = self.len();
+        unsafe { self.commit_unchecked(slots) };
+    }
+
+    unsafe fn commit_unchecked(self, n: usize) -> usize {
+        let head = self.consumer.head.get();
+        // Safety: head has not yet been incremented
+        let ptr = self.consumer.buffer.slot_ptr(head);
+        let first_len = self.first_len.min(n);
+        for i in 0..first_len {
+            ptr.add(i).drop_in_place();
+        }
+        let ptr = self.consumer.buffer.data_ptr;
+        let second_len = self.second_len.min(n - first_len);
+        for i in 0..second_len {
+            ptr.add(i).drop_in_place();
+        }
+        let head = self.consumer.buffer.increment(head, n);
+        self.consumer.buffer.head.store(head, Ordering::Release);
+        self.consumer.head.set(head);
+        n
+    }
+
+    /// Returns the number of slots in the chunk.
+    pub fn len(&self) -> usize {
+        self.first_len + self.second_len
+    }
+
+    /// Returns `true` if the chunk contains no slots.
+    pub fn is_empty(&self) -> bool {
+        self.first_len == 0
+    }
+}
+
+impl<'a, T> Iterator for ReadChunk<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let ptr = if self.iterated < self.first_len {
+            unsafe { self.first_ptr.add(self.iterated) }
+        } else if self.iterated < self.first_len + self.second_len {
+            unsafe { self.second_ptr.add(self.iterated - self.first_len) }
+        } else {
+            return None;
+        };
+        self.iterated += 1;
+        Some(unsafe { &*ptr })
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Write for Producer<u8> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        use ChunkError::TooFewSlots;
+        let mut chunk = match self.write_chunk_uninit(buf.len()) {
+            Ok(chunk) => chunk,
+            Err(TooFewSlots(0)) => return Err(std::io::ErrorKind::WouldBlock.into()),
+            Err(TooFewSlots(n)) => self.write_chunk_uninit(n).unwrap(),
+        };
+        let end = chunk.len();
+        let (first, second) = chunk.as_mut_slices();
+        let mid = first.len();
+        // NB: If buf.is_empty(), chunk will be empty as well and the following are no-ops:
+        buf[..mid].copy_to_uninit(first);
+        buf[mid..end].copy_to_uninit(second);
+        // Safety: All slots have been initialized
+        unsafe {
+            chunk.commit_all();
+        }
+        Ok(end)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // Nothing to do here.
+        Ok(())
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Read for Consumer<u8> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        use ChunkError::TooFewSlots;
+        let chunk = match self.read_chunk(buf.len()) {
+            Ok(chunk) => chunk,
+            Err(TooFewSlots(0)) => return Err(std::io::ErrorKind::WouldBlock.into()),
+            Err(TooFewSlots(n)) => self.read_chunk(n).unwrap(),
+        };
+        let (first, second) = chunk.as_slices();
+        let mid = first.len();
+        let end = chunk.len();
+        // NB: If buf.is_empty(), chunk will be empty as well and the following are no-ops:
+        buf[..mid].copy_from_slice(first);
+        buf[mid..end].copy_from_slice(second);
+        chunk.commit_all();
+        Ok(end)
+    }
+}
+
+/// Error type for [`Consumer::read_chunk()`], [`Producer::write_chunk()`]
+/// and [`Producer::write_chunk_uninit()`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ChunkError {
+    /// Fewer than the requested number of slots were available.
+    ///
+    /// Contains the number of slots that were available.
+    TooFewSlots(usize),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ChunkError {}
+
+impl fmt::Display for ChunkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ChunkError::TooFewSlots(n) => {
+                alloc::format!("only {} slots available in ring buffer", n).fmt(f)
+            }
+        }
+    }
+}

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -76,7 +76,7 @@
 //! The following examples show the [`Producer`] side;
 //! similar patterns can of course be used with [`Consumer::read_chunk()`] as well.
 //! Furthermore, the examples use [`Producer::write_chunk()`],
-//! which requires the trait bounds `T: Copy + Default`.
+//! which requires the trait bound `T: Default`.
 //! If that's too restrictive or if you want to squeeze out the last bit of performance,
 //! you can use [`Producer::write_chunk_uninit()`] instead,
 //! but this will force you to write some `unsafe` code.
@@ -139,7 +139,7 @@
 //!
 //! fn push_from_iter<T, I>(queue: &mut Producer<T>, iter: &mut I) -> usize
 //! where
-//!     T: Copy + Default,
+//!     T: Default,
 //!     I: Iterator<Item = T>,
 //! {
 //!     let n = match iter.size_hint() {
@@ -184,10 +184,6 @@ impl<T> Producer<T> {
     /// This has to be explicitly done by calling [`WriteChunk::commit()`],
     /// [`WriteChunk::commit_iterated()`] or [`WriteChunk::commit_all()`].
     ///
-    /// The type parameter `T` has a trait bound of [`Copy`],
-    /// which makes sure that no destructors are called at any time
-    /// (because it implies [`!Drop`](Drop)).
-    ///
     /// For an unsafe alternative that has no restrictions on `T`,
     /// see [`Producer::write_chunk_uninit()`].
     ///
@@ -196,7 +192,7 @@ impl<T> Producer<T> {
     /// See the documentation of the [`chunks`](crate::chunks#examples) module for more examples.
     pub fn write_chunk(&mut self, n: usize) -> Result<WriteChunk<'_, T>, ChunkError>
     where
-        T: Copy + Default,
+        T: Default,
     {
         self.write_chunk_uninit(n).map(WriteChunk::from)
     }
@@ -369,7 +365,7 @@ pub struct WriteChunk<'a, T>(WriteChunkUninit<'a, T>);
 
 impl<'a, T> From<WriteChunkUninit<'a, T>> for WriteChunk<'a, T>
 where
-    T: Copy + Default,
+    T: Default,
 {
     /// Fills all slots with the [`Default`] value.
     fn from(chunk: WriteChunkUninit<'a, T>) -> Self {
@@ -389,7 +385,7 @@ where
 
 impl<T> WriteChunk<'_, T>
 where
-    T: Copy + Default,
+    T: Default,
 {
     /// Returns two slices for writing to the requested slots.
     ///
@@ -442,7 +438,7 @@ where
 
 impl<'a, T> Iterator for WriteChunk<'a, T>
 where
-    T: Copy + Default,
+    T: Default,
 {
     type Item = &'a mut T;
 

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -360,7 +360,7 @@ impl<T> Consumer<T> {
 /// [`commit()`](WriteChunk::commit),
 /// [`commit_iterated()`](WriteChunk::commit_iterated) or
 /// [`commit_all()`](WriteChunk::commit_all).
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct WriteChunk<'a, T>(WriteChunkUninit<'a, T>);
 
 impl<'a, T> From<WriteChunkUninit<'a, T>> for WriteChunk<'a, T>
@@ -470,7 +470,7 @@ where
 /// [`commit()`](WriteChunkUninit::commit),
 /// [`commit_iterated()`](WriteChunkUninit::commit_iterated) or
 /// [`commit_all()`](WriteChunkUninit::commit_all).
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct WriteChunkUninit<'a, T> {
     first_ptr: *mut T,
     first_len: usize,

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -15,7 +15,7 @@
 //! ```
 //! use rtrb::RingBuffer;
 //!
-//! let (mut producer, mut consumer) = RingBuffer::new(5).split();
+//! let (mut producer, mut consumer) = RingBuffer::new(5);
 //!
 //! if let Ok(mut chunk) = producer.write_chunk(4) {
 //!     // NB: Don't use `chunk` as the first iterator in zip() if the other one might be shorter!
@@ -285,7 +285,7 @@ impl<T> Consumer<T> {
     ///
     /// // Scope to limit lifetime of ring buffer
     /// {
-    ///     let (mut p, mut c) = RingBuffer::new(2).split();
+    ///     let (mut p, mut c) = RingBuffer::new(2);
     ///
     ///     assert!(p.push(Thing).is_ok()); // 1
     ///     assert!(p.push(Thing).is_ok()); // 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,9 +99,6 @@ impl<T> RingBuffer<T> {
     /// The returned `RingBuffer` is typically immediately split into
     /// the [`Producer`] and the [`Consumer`] side by [`split()`](RingBuffer::split).
     ///
-    /// If you want guaranteed wrap-around behavior,
-    /// use [`with_chunks()`](RingBuffer::with_chunks).
-    ///
     /// # Examples
     ///
     /// ```
@@ -158,8 +155,6 @@ impl<T> RingBuffer<T> {
     /// This drops all elements that are currently in the queue
     /// (running their destructors if `T` implements [`Drop`]) and
     /// resets the internal read and write positions to the beginning of the buffer.
-    ///
-    /// This also resets the guarantees given by [`with_chunks()`](RingBuffer::with_chunks).
     ///
     /// Exclusive access to both [`Producer`] and [`Consumer`] is needed for this operation.
     /// They can be moved between threads, for example, with a `RingBuffer<Producer<T>>`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,62 +150,6 @@ impl<T> RingBuffer<T> {
         (p, c)
     }
 
-    /// Resets a ring buffer.
-    ///
-    /// This drops all elements that are currently in the queue
-    /// (running their destructors if `T` implements [`Drop`]) and
-    /// resets the internal read and write positions to the beginning of the buffer.
-    ///
-    /// Exclusive access to both [`Producer`] and [`Consumer`] is needed for this operation.
-    /// They can be moved between threads, for example, with a `RingBuffer<Producer<T>>`
-    /// and a `RingBuffer<Consumer<T>>`, respectively.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the `producer` and `consumer` do not originate from the same `RingBuffer`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rtrb::RingBuffer;
-    ///
-    /// let (mut p, mut c) = RingBuffer::new(2).split();
-    ///
-    /// p = std::thread::spawn(move || {
-    ///     assert_eq!(p.push(10), Ok(()));
-    ///     p
-    /// }).join().unwrap();
-    ///
-    /// RingBuffer::reset(&mut p, &mut c);
-    ///
-    /// // The full capacity is now available for writing:
-    /// if let Ok(mut chunk) = p.write_chunk(p.buffer().capacity()) {
-    ///     let (first, second) = chunk.as_mut_slices();
-    ///     // The first slice is now guaranteed to span the whole buffer:
-    ///     first[0] = 20;
-    ///     first[1] = 30;
-    ///     assert!(second.is_empty());
-    ///     chunk.commit_all();
-    /// } else {
-    ///     unreachable!();
-    /// }
-    /// ```
-    pub fn reset(producer: &mut Producer<T>, consumer: &mut Consumer<T>) {
-        assert!(
-            Arc::ptr_eq(&producer.buffer, &consumer.buffer),
-            "producer and consumer not from the same ring buffer"
-        );
-        consumer.read_chunk(consumer.slots()).unwrap().commit_all();
-        assert_eq!(
-            producer.buffer.head.swap(0, Ordering::Relaxed),
-            producer.buffer.tail.swap(0, Ordering::Relaxed)
-        );
-        producer.head.set(0);
-        producer.tail.set(0);
-        consumer.head.set(0);
-        consumer.tail.set(0);
-    }
-
     /// Returns the capacity of the queue.
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ impl<T> Eq for RingBuffer<T> {}
 /// that no more data will be produced.
 /// When the `Producer` is dropped after the [`Consumer`] has already been dropped,
 /// [`RingBuffer::drop()`] will be called, freeing the allocated memory.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Producer<T> {
     /// A reference to the ring buffer.
     buffer: Arc<RingBuffer<T>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,158 +39,9 @@
 //! }).join().unwrap();
 //! ```
 //!
-//! Producing and consuming multiple items at once with
-//! [`Producer::write_chunk()`] and [`Consumer::read_chunk()`], respectively.
-//! This example uses a single thread for simplicity, but in a real application,
-//! `producer` and `consumer` would of course live on different threads:
-//!
-//! ```
-//! use rtrb::RingBuffer;
-//!
-//! let (mut producer, mut consumer) = RingBuffer::new(5).split();
-//!
-//! if let Ok(mut chunk) = producer.write_chunk(4) {
-//!     // NB: Don't use `chunk` as the first iterator in zip() if the other one might be shorter!
-//!     for (src, dst) in vec![10, 11, 12].into_iter().zip(&mut chunk) {
-//!         *dst = src;
-//!     }
-//!     // Don't forget to make the written slots available for reading!
-//!     chunk.commit_iterated();
-//!     // Note that we requested 4 slots but we've only written 3!
-//! } else {
-//!     unreachable!();
-//! }
-//!
-//! assert_eq!(producer.slots(), 2);
-//! assert_eq!(consumer.slots(), 3);
-//!
-//! if let Ok(mut chunk) = consumer.read_chunk(2) {
-//!     // NB: Even though we are just reading, `chunk` needs to be mutable for iteration!
-//!     assert_eq!((&mut chunk).collect::<Vec<_>>(), [&10, &11]);
-//!     chunk.commit_iterated(); // Mark the slots as "consumed"
-//!     // chunk.commit_all() would also work here.
-//! } else {
-//!     unreachable!();
-//! }
-//!
-//! // One element is still in the queue:
-//! assert_eq!(consumer.peek(), Ok(&12));
-//!
-//! let data = vec![20, 21, 22, 23];
-//! if let Ok(mut chunk) = producer.write_chunk(4) {
-//!     let (first, second) = chunk.as_mut_slices();
-//!     let mid = first.len();
-//!     first.copy_from_slice(&data[..mid]);
-//!     second.copy_from_slice(&data[mid..]);
-//!     chunk.commit_all();
-//! } else {
-//!     unreachable!();
-//! }
-//!
-//! assert!(producer.is_full());
-//! assert_eq!(consumer.slots(), 5);
-//!
-//! let mut v = Vec::<i32>::with_capacity(5);
-//! if let Ok(chunk) = consumer.read_chunk(5) {
-//!     let (first, second) = chunk.as_slices();
-//!     v.extend(first);
-//!     v.extend(second);
-//!     chunk.commit_all();
-//! } else {
-//!     unreachable!();
-//! }
-//! assert_eq!(v, [12, 20, 21, 22, 23]);
-//! assert!(consumer.is_empty());
-//! ```
-//!
-//! ## Common Access Patterns
-//!
-//! The following examples show the [`Producer`] side;
-//! similar patterns can of course be used with [`Consumer::read_chunk()`] as well.
-//! Furthermore, the examples use [`Producer::write_chunk()`],
-//! which requires the trait bounds `T: Copy + Default`.
-//! If that's too restrictive or if you want to squeeze out the last bit of performance,
-//! you can use [`Producer::write_chunk_uninit()`] instead,
-//! but this will force you to write some `unsafe` code.
-//!
-//! Copy a whole slice of items into the ring buffer, but only if space permits
-//! (if not, the input slice is returned as an error):
-//!
-//! ```
-//! use rtrb::Producer;
-//!
-//! fn push_entire_slice<'a, T>(queue: &mut Producer<T>, slice: &'a [T]) -> Result<(), &'a [T]>
-//! where
-//!     T: Copy + Default,
-//! {
-//!     if let Ok(mut chunk) = queue.write_chunk(slice.len()) {
-//!         let (first, second) = chunk.as_mut_slices();
-//!         let mid = first.len();
-//!         first.copy_from_slice(&slice[..mid]);
-//!         second.copy_from_slice(&slice[mid..]);
-//!         chunk.commit_all();
-//!         Ok(())
-//!     } else {
-//!         Err(slice)
-//!     }
-//! }
-//! ```
-//!
-//! Copy as many items as possible from a given slice, returning the remainder of the slice
-//! (which will be empty if there was space for all items):
-//!
-//! ```
-//! use rtrb::{Producer, ChunkError::TooFewSlots};
-//!
-//! fn push_partial_slice<'a, T>(queue: &mut Producer<T>, slice: &'a [T]) -> &'a [T]
-//! where
-//!     T: Copy + Default,
-//! {
-//!     let mut chunk = match queue.write_chunk(slice.len()) {
-//!         Ok(chunk) => chunk,
-//!         // This is an optional optimization if the queue tends to be full:
-//!         Err(TooFewSlots(0)) => return slice,
-//!         // Remaining slots are returned, this will always succeed:
-//!         Err(TooFewSlots(n)) => queue.write_chunk(n).unwrap(),
-//!     };
-//!     let end = chunk.len();
-//!     let (first, second) = chunk.as_mut_slices();
-//!     let mid = first.len();
-//!     first.copy_from_slice(&slice[..mid]);
-//!     second.copy_from_slice(&slice[mid..end]);
-//!     chunk.commit_all();
-//!     &slice[end..]
-//! }
-//! ```
-//!
-//! Write as many slots as possible, given an iterator
-//! (and return the number of written slots):
-//!
-//! ```
-//! use rtrb::{Producer, ChunkError::TooFewSlots};
-//!
-//! fn push_from_iter<T, I>(queue: &mut Producer<T>, iter: &mut I) -> usize
-//! where
-//!     T: Copy + Default,
-//!     I: Iterator<Item = T>,
-//! {
-//!     let n = match iter.size_hint() {
-//!         (_, None) => queue.slots(),
-//!         (_, Some(n)) => n,
-//!     };
-//!     let mut chunk = match queue.write_chunk(n) {
-//!         Ok(chunk) => chunk,
-//!         // As above, this is an optional optimization:
-//!         Err(TooFewSlots(0)) => return 0,
-//!         // As above, this will always succeed:
-//!         Err(TooFewSlots(n)) => queue.write_chunk(n).unwrap(),
-//!     };
-//!     for (source, target) in iter.zip(&mut chunk) {
-//!         *target = source;
-//!     }
-//!     chunk.commit_iterated()
-//! }
-//! ```
+//! For examples that write multiple items at once with [`Producer::write_chunk()`]
+//! and read multiple items with [`Consumer::read_chunk()`]
+//! see the documentation of the [`chunks#examples`] module.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(rust_2018_idioms)]
@@ -208,7 +59,13 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 
 use cache_padded::CachePadded;
 
-/// A bounded single-producer single-consumer queue.
+pub mod chunks;
+
+// This is used in the documentation.
+#[allow(unused_imports)]
+use chunks::WriteChunkUninit;
+
+/// A bounded single-producer single-consumer (SPSC) queue.
 ///
 /// Elements can be written with a [`Producer`] and read with a [`Consumer`],
 /// both of which can be obtained with [`RingBuffer::split()`].
@@ -270,27 +127,6 @@ impl<T> RingBuffer<T> {
             capacity,
             _marker: PhantomData,
         }
-    }
-
-    /// Creates a `RingBuffer` with a capacity of `chunks * chunk_size`.
-    ///
-    /// On top of multiplying the two numbers for us,
-    /// this also guarantees that the ring buffer wrap-around happens
-    /// at an integer multiple of `chunk_size`.
-    /// This means that if [`Consumer::read_chunk()`] is used *exclusively* with
-    /// `chunk_size` (and [`Consumer::pop()`] is *not* used in-between),
-    /// the first slice returned from [`ReadChunk::as_slices()`]
-    /// will always contain the entire chunk and the second slice will always be empty.
-    /// Same for [`Producer::write_chunk()`]/[`WriteChunk::as_mut_slices()`] and
-    /// [`Producer::write_chunk_uninit()`]/[`WriteChunkUninit::as_mut_slices()`]
-    /// (as long as [`Producer::push()`] is *not* used in-between).
-    ///
-    /// If above conditions have been violated, the wrap-around guarantee can be restored
-    /// wit [`reset()`](RingBuffer::reset).
-    pub fn with_chunks(chunks: usize, chunk_size: usize) -> RingBuffer<T> {
-        // NB: Currently, there is nothing special to do here, but in the future
-        //     it might be necessary to take some steps to guarantee the promised behavior.
-        Self::new(chunks * chunk_size)
     }
 
     /// Splits the `RingBuffer` into [`Producer`] and [`Consumer`].
@@ -497,19 +333,18 @@ impl<T> Eq for RingBuffer<T> {}
 /// Can only be created with [`RingBuffer::split()`]
 /// (together with its counterpart, the [`Consumer`]).
 ///
+/// Individual elements can be moved into the ring buffer with [`Producer::push()`],
+/// multiple elements at once can be written with [`Producer::write_chunk()`]
+/// and [`Producer::write_chunk_uninit()`].
+///
+/// The number of free slots currently available for writing can be obtained with
+/// [`Producer::slots()`].
+///
 /// When the `Producer` is dropped, [`Consumer::is_abandoned()`] will return `true`.
 /// This can be used as a crude way to communicate to the receiving thread
 /// that no more data will be produced.
 /// When the `Producer` is dropped after the [`Consumer`] has already been dropped,
 /// [`RingBuffer::drop()`] will be called, freeing the allocated memory.
-///
-/// # Examples
-///
-/// ```
-/// use rtrb::RingBuffer;
-///
-/// let (producer, consumer) = RingBuffer::<f32>::new(1000).split();
-/// ```
 #[derive(Debug)]
 pub struct Producer<T> {
     /// A reference to the ring buffer.
@@ -559,84 +394,6 @@ impl<T> Producer<T> {
         }
     }
 
-    /// Returns `n` slots (initially containing their [`Default`] value) for writing.
-    ///
-    /// If not enough slots are available, an error
-    /// (containing the number of available slots) is returned.
-    ///
-    /// The elements can be accessed with [`WriteChunk::as_mut_slices()`] or
-    /// by iterating over (a `&mut` to) the [`WriteChunk`].
-    ///
-    /// The provided slots are *not* automatically made available
-    /// to be read by the [`Consumer`].
-    /// This has to be explicitly done by calling [`WriteChunk::commit()`],
-    /// [`WriteChunk::commit_iterated()`] or [`WriteChunk::commit_all()`].
-    ///
-    /// The type parameter `T` has a trait bound of [`Copy`],
-    /// which makes sure that no destructors are called at any time
-    /// (because it implies [`!Drop`](Drop)).
-    ///
-    /// For an unsafe alternative that has no restrictions on `T`,
-    /// see [`Producer::write_chunk_uninit()`].
-    ///
-    /// # Examples
-    ///
-    /// See the [crate-level documentation](crate#examples) for examples.
-    pub fn write_chunk(&mut self, n: usize) -> Result<WriteChunk<'_, T>, ChunkError>
-    where
-        T: Copy + Default,
-    {
-        self.write_chunk_uninit(n).map(WriteChunk::from)
-    }
-
-    /// Returns `n` (uninitialized) slots for writing.
-    ///
-    /// If not enough slots are available, an error
-    /// (containing the number of available slots) is returned.
-    ///
-    /// The elements can be accessed with [`WriteChunkUninit::as_mut_slices()`] or
-    /// by iterating over (a `&mut` to) the [`WriteChunkUninit`].
-    ///
-    /// The provided slots are *not* automatically made available
-    /// to be read by the [`Consumer`].
-    /// This has to be explicitly done by calling [`WriteChunkUninit::commit()`],
-    /// [`WriteChunkUninit::commit_iterated()`] or
-    /// [`WriteChunkUninit::commit_all()`].
-    ///
-    /// # Safety
-    ///
-    /// This function itself is safe, but accessing the returned slots might not be,
-    /// as well as invoking some methods of [`WriteChunkUninit`].
-    ///
-    /// For a safe alternative that provides [`Default`]-initialized slots,
-    /// see [`Producer::write_chunk()`].
-    pub fn write_chunk_uninit(&mut self, n: usize) -> Result<WriteChunkUninit<'_, T>, ChunkError> {
-        let tail = self.tail.get();
-
-        // Check if the queue has *possibly* not enough slots.
-        if self.buffer.capacity - self.buffer.distance(self.head.get(), tail) < n {
-            // Refresh the head ...
-            let head = self.buffer.head.load(Ordering::Acquire);
-            self.head.set(head);
-
-            // ... and check if there *really* are not enough slots.
-            let slots = self.buffer.capacity - self.buffer.distance(head, tail);
-            if slots < n {
-                return Err(ChunkError::TooFewSlots(slots));
-            }
-        }
-        let tail = self.buffer.collapse_position(tail);
-        let first_len = n.min(self.buffer.capacity - tail);
-        Ok(WriteChunkUninit {
-            first_ptr: unsafe { self.buffer.data_ptr.add(tail) },
-            first_len,
-            second_ptr: self.buffer.data_ptr,
-            second_len: n - first_len,
-            producer: self,
-            iterated: 0,
-        })
-    }
-
     /// Returns the number of slots available for writing.
     ///
     /// Since items can be concurrently consumed on another thread, the actual number
@@ -662,6 +419,9 @@ impl<T> Producer<T> {
     }
 
     /// Returns `true` if there are currently no slots available for writing.
+    ///
+    /// A full ring buffer might cease to be full at any time
+    /// if the corresponding [`Consumer`] is consuming items in another thread.
     ///
     /// # Examples
     ///
@@ -776,19 +536,17 @@ impl<T> Producer<T> {
 /// Can only be created with [`RingBuffer::split()`]
 /// (together with its counterpart, the [`Producer`]).
 ///
+/// Individual elements can be moved out of the ring buffer with [`Consumer::pop()`],
+/// multiple elements at once can be read with [`Consumer::read_chunk()`].
+///
+/// The number of free slots currently available for reading can be obtained with
+/// [`Consumer::slots()`].
+///
 /// When the `Consumer` is dropped, [`Producer::is_abandoned()`] will return `true`.
 /// This can be used as a crude way to communicate to the sending thread
 /// that no more data will be consumed.
 /// When the `Consumer` is dropped after the [`Producer`] has already been dropped,
 /// [`RingBuffer::drop()`] will be called, freeing the allocated memory.
-///
-/// # Examples
-///
-/// ```
-/// use rtrb::RingBuffer;
-///
-/// let (producer, consumer) = RingBuffer::<f32>::new(1000).split();
-/// ```
 #[derive(Debug, PartialEq, Eq)]
 pub struct Consumer<T> {
     /// A reference to the ring buffer.
@@ -870,98 +628,6 @@ impl<T> Consumer<T> {
         }
     }
 
-    /// Returns `n` slots for reading.
-    ///
-    /// If not enough slots are available, an error
-    /// (containing the number of available slots) is returned.
-    ///
-    /// The elements can be accessed with [`ReadChunk::as_slices()`] or
-    /// by iterating over (a `&mut` to) the [`ReadChunk`].
-    ///
-    /// The provided slots are *not* automatically made available
-    /// to be written again by the [`Producer`].
-    /// This has to be explicitly done by calling [`ReadChunk::commit()`],
-    /// [`ReadChunk::commit_iterated()`] or [`ReadChunk::commit_all()`].
-    /// You can "peek" at the contained values by simply
-    /// not calling any of the "commit" methods.
-    ///
-    /// # Examples
-    ///
-    /// Items are dropped when [`ReadChunk::commit()`], [`ReadChunk::commit_iterated()`]
-    /// or [`ReadChunk::commit_all()`] is called
-    /// (which is only relevant if `T` implements [`Drop`]).
-    ///
-    /// ```
-    /// use rtrb::RingBuffer;
-    ///
-    /// // Static variable to count all drop() invocations
-    /// static mut DROP_COUNT: i32 = 0;
-    /// #[derive(Debug)]
-    /// struct Thing;
-    /// impl Drop for Thing {
-    ///     fn drop(&mut self) { unsafe { DROP_COUNT += 1; } }
-    /// }
-    ///
-    /// // Scope to limit lifetime of ring buffer
-    /// {
-    ///     let (mut p, mut c) = RingBuffer::new(2).split();
-    ///
-    ///     assert!(p.push(Thing).is_ok()); // 1
-    ///     assert!(p.push(Thing).is_ok()); // 2
-    ///     if let Ok(thing) = c.pop() {
-    ///         // "thing" has been *moved* out of the queue but not yet dropped
-    ///         assert_eq!(unsafe { DROP_COUNT }, 0);
-    ///     } else {
-    ///         unreachable!();
-    ///     }
-    ///     // First Thing has been dropped when "thing" went out of scope:
-    ///     assert_eq!(unsafe { DROP_COUNT }, 1);
-    ///     assert!(p.push(Thing).is_ok()); // 3
-    ///
-    ///     if let Ok(chunk) = c.read_chunk(2) {
-    ///         assert_eq!(chunk.len(), 2);
-    ///         assert_eq!(unsafe { DROP_COUNT }, 1);
-    ///         chunk.commit(1); // Drops only one of the two Things
-    ///         assert_eq!(unsafe { DROP_COUNT }, 2);
-    ///     } else {
-    ///         unreachable!();
-    ///     }
-    ///     // The last Thing is still in the queue ...
-    ///     assert_eq!(unsafe { DROP_COUNT }, 2);
-    /// }
-    /// // ... and it is dropped when the ring buffer goes out of scope:
-    /// assert_eq!(unsafe { DROP_COUNT }, 3);
-    /// ```
-    ///
-    /// See the [crate-level documentation](crate#examples) for more examples.
-    pub fn read_chunk(&mut self, n: usize) -> Result<ReadChunk<'_, T>, ChunkError> {
-        let head = self.head.get();
-
-        // Check if the queue has *possibly* not enough slots.
-        if self.buffer.distance(head, self.tail.get()) < n {
-            // Refresh the tail ...
-            let tail = self.buffer.tail.load(Ordering::Acquire);
-            self.tail.set(tail);
-
-            // ... and check if there *really* are not enough slots.
-            let slots = self.buffer.distance(head, tail);
-            if slots < n {
-                return Err(ChunkError::TooFewSlots(slots));
-            }
-        }
-
-        let head = self.buffer.collapse_position(head);
-        let first_len = n.min(self.buffer.capacity - head);
-        Ok(ReadChunk {
-            first_ptr: unsafe { self.buffer.data_ptr.add(head) },
-            first_len,
-            second_ptr: self.buffer.data_ptr,
-            second_len: n - first_len,
-            consumer: self,
-            iterated: 0,
-        })
-    }
-
     /// Returns the number of slots available for reading.
     ///
     /// Since items can be concurrently produced on another thread, the actual number
@@ -987,6 +653,9 @@ impl<T> Consumer<T> {
     }
 
     /// Returns `true` if there are currently no slots available for reading.
+    ///
+    /// An empty ring buffer might cease to be empty at any time
+    /// if the corresponding [`Producer`] is producing items in another thread.
     ///
     /// # Examples
     ///
@@ -1091,237 +760,6 @@ impl<T> Consumer<T> {
     }
 }
 
-/// Structure for writing into multiple ([`Default`]-initialized) slots in one go.
-///
-/// This is returned from [`Producer::write_chunk()`].
-///
-/// For an unsafe alternative that provides uninitialized slots,
-/// see [`WriteChunkUninit`].
-///
-/// The slots (which initially contain [`Default`] values) can be accessed with
-/// [`as_mut_slices()`](WriteChunk::as_mut_slices)
-/// or by iteration, which yields mutable references (in other words: `&mut T`).
-/// A mutable reference (`&mut`) to the `WriteChunk`
-/// should be used to iterate over it.
-/// Each slot can only be iterated once and the number of iterations is tracked.
-///
-/// After writing, the provided slots are *not* automatically made available
-/// to be read by the [`Consumer`].
-/// If desired, this has to be explicitly done by calling
-/// [`commit()`](WriteChunk::commit),
-/// [`commit_iterated()`](WriteChunk::commit_iterated) or
-/// [`commit_all()`](WriteChunk::commit_all).
-#[derive(Debug)]
-pub struct WriteChunk<'a, T>(WriteChunkUninit<'a, T>);
-
-impl<'a, T> From<WriteChunkUninit<'a, T>> for WriteChunk<'a, T>
-where
-    T: Copy + Default,
-{
-    /// Fills all slots with the [`Default`] value.
-    fn from(chunk: WriteChunkUninit<'a, T>) -> Self {
-        for i in 0..chunk.first_len {
-            unsafe {
-                chunk.first_ptr.add(i).write(Default::default());
-            }
-        }
-        for i in 0..chunk.second_len {
-            unsafe {
-                chunk.second_ptr.add(i).write(Default::default());
-            }
-        }
-        WriteChunk(chunk)
-    }
-}
-
-impl<T> WriteChunk<'_, T>
-where
-    T: Copy + Default,
-{
-    /// Returns two slices for writing to the requested slots.
-    ///
-    /// All slots are initially filled with their [`Default`] value.
-    ///
-    /// The first slice can only be empty if `0` slots have been requested.
-    /// If the first slice contains all requested slots, the second one is empty.
-    ///
-    /// See [`RingBuffer::with_chunks()`] for a way to make sure
-    /// that the second slice is always empty.
-    pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
-        // Safety: All slots have been initialized in From::from().
-        unsafe {
-            (
-                core::slice::from_raw_parts_mut(self.0.first_ptr, self.0.first_len),
-                core::slice::from_raw_parts_mut(self.0.second_ptr, self.0.second_len),
-            )
-        }
-    }
-
-    /// Makes the first `n` slots of the chunk available for reading.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n` is greater than the number of slots in the chunk.
-    pub fn commit(self, n: usize) {
-        // Safety: All slots have been initialized in From::from() and there are no destructors.
-        unsafe { self.0.commit(n) }
-    }
-
-    /// Returns the number of iterated slots and makes them available for reading.
-    pub fn commit_iterated(self) -> usize {
-        // Safety: All slots have been initialized in From::from() and there are no destructors.
-        unsafe { self.0.commit_iterated() }
-    }
-
-    /// Makes the whole chunk available for reading.
-    pub fn commit_all(self) {
-        // Safety: All slots have been initialized in From::from().
-        unsafe { self.0.commit_all() }
-    }
-
-    /// Returns the number of slots in the chunk.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns `true` if the chunk contains no slots.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl<'a, T> Iterator for WriteChunk<'a, T>
-where
-    T: Copy + Default,
-{
-    type Item = &'a mut T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|item| {
-            // Safety: All slots have been initialized in From::from().
-            unsafe { &mut *item.as_mut_ptr() }
-        })
-    }
-}
-
-/// Structure for writing into multiple (uninitialized) slots in one go.
-///
-/// This is returned from [`Producer::write_chunk_uninit()`].
-///
-/// For a safe alternative that provides [`Default`]-initialized slots, see [`WriteChunk`].
-///
-/// The slots can be accessed with
-/// [`as_mut_slices()`](WriteChunkUninit::as_mut_slices)
-/// or by iteration, which yields mutable references to possibly uninitialized data
-/// (in other words: `&mut MaybeUninit<T>`).
-/// A mutable reference (`&mut`) to the `WriteChunkUninit`
-/// should be used to iterate over it.
-/// Each slot can only be iterated once and the number of iterations is tracked.
-///
-/// After writing, the provided slots are *not* automatically made available
-/// to be read by the [`Consumer`].
-/// If desired, this has to be explicitly done by calling
-/// [`commit()`](WriteChunkUninit::commit),
-/// [`commit_iterated()`](WriteChunkUninit::commit_iterated) or
-/// [`commit_all()`](WriteChunkUninit::commit_all).
-#[derive(Debug)]
-pub struct WriteChunkUninit<'a, T> {
-    first_ptr: *mut T,
-    first_len: usize,
-    second_ptr: *mut T,
-    second_len: usize,
-    producer: &'a Producer<T>,
-    iterated: usize,
-}
-
-impl<T> WriteChunkUninit<'_, T> {
-    /// Returns two slices for writing to the requested slots.
-    ///
-    /// The first slice can only be empty if `0` slots have been requested.
-    /// If the first slice contains all requested slots, the second one is empty.
-    ///
-    /// See [`RingBuffer::with_chunks()`] for a way to make sure
-    /// that the second slice is always empty.
-    ///
-    /// The extension trait [`CopyToUninit`] can be used to safely copy data into those slices.
-    pub fn as_mut_slices(&mut self) -> (&mut [MaybeUninit<T>], &mut [MaybeUninit<T>]) {
-        unsafe {
-            (
-                core::slice::from_raw_parts_mut(self.first_ptr as *mut _, self.first_len),
-                core::slice::from_raw_parts_mut(self.second_ptr as *mut _, self.second_len),
-            )
-        }
-    }
-
-    /// Makes the first `n` slots of the chunk available for reading.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n` is greater than the number of slots in the chunk.
-    ///
-    /// # Safety
-    ///
-    /// The user must make sure that the first `n` elements
-    /// (and not more, in case `T` implements [`Drop`]) have been initialized.
-    pub unsafe fn commit(self, n: usize) {
-        assert!(n <= self.len(), "cannot commit more than chunk size");
-        self.commit_unchecked(n);
-    }
-
-    /// Returns the number of iterated slots and makes them available for reading.
-    ///
-    /// # Safety
-    ///
-    /// The user must make sure that all iterated elements have been initialized.
-    pub unsafe fn commit_iterated(self) -> usize {
-        let slots = self.iterated;
-        self.commit_unchecked(slots)
-    }
-
-    /// Makes the whole chunk available for reading.
-    ///
-    /// # Safety
-    ///
-    /// The user must make sure that all elements have been initialized.
-    pub unsafe fn commit_all(self) {
-        let slots = self.len();
-        self.commit_unchecked(slots);
-    }
-
-    unsafe fn commit_unchecked(self, n: usize) -> usize {
-        let tail = self.producer.buffer.increment(self.producer.tail.get(), n);
-        self.producer.buffer.tail.store(tail, Ordering::Release);
-        self.producer.tail.set(tail);
-        n
-    }
-
-    /// Returns the number of slots in the chunk.
-    pub fn len(&self) -> usize {
-        self.first_len + self.second_len
-    }
-
-    /// Returns `true` if the chunk contains no slots.
-    pub fn is_empty(&self) -> bool {
-        self.first_len == 0
-    }
-}
-
-impl<'a, T> Iterator for WriteChunkUninit<'a, T> {
-    type Item = &'a mut MaybeUninit<T>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let ptr = if self.iterated < self.first_len {
-            unsafe { self.first_ptr.add(self.iterated) }
-        } else if self.iterated < self.first_len + self.second_len {
-            unsafe { self.second_ptr.add(self.iterated - self.first_len) }
-        } else {
-            return None;
-        };
-        self.iterated += 1;
-        Some(unsafe { &mut *(ptr as *mut _) })
-    }
-}
-
 /// Extension trait used to provide a [`copy_to_uninit()`](CopyToUninit::copy_to_uninit)
 /// method on built-in slices.
 ///
@@ -1352,166 +790,6 @@ impl<T: Copy> CopyToUninit<T> for [T] {
         );
         let dst_ptr = dst.as_mut_ptr() as *mut _;
         unsafe { self.as_ptr().copy_to_nonoverlapping(dst_ptr, self.len()) };
-    }
-}
-
-/// Structure for reading from multiple slots in one go.
-///
-/// This is returned from [`Consumer::read_chunk()`].
-///
-/// The slots can be accessed with [`as_slices()`](ReadChunk::as_slices)
-/// or by iteration.
-/// Even though iterating yields immutable references (`&T`),
-/// a mutable reference (`&mut`) to the `ReadChunk` should be used to iterate over it.
-/// Each slot can only be iterated once and the number of iterations is tracked.
-///
-/// After reading, the provided slots are *not* automatically made available
-/// to be written again by the [`Producer`].
-/// If desired, this has to be explicitly done by calling [`commit()`](ReadChunk::commit),
-/// [`commit_iterated()`](ReadChunk::commit_iterated) or [`commit_all()`](ReadChunk::commit_all).
-/// Note that this runs the destructor of the committed items (if `T` implements [`Drop`]).
-#[derive(Debug, PartialEq, Eq)]
-pub struct ReadChunk<'a, T> {
-    first_ptr: *const T,
-    first_len: usize,
-    second_ptr: *const T,
-    second_len: usize,
-    consumer: &'a mut Consumer<T>,
-    iterated: usize,
-}
-
-impl<T> ReadChunk<'_, T> {
-    /// Returns two slices for reading from the requested slots.
-    ///
-    /// The first slice can only be empty if `0` slots have been requested.
-    /// If the first slice contains all requested slots, the second one is empty.
-    ///
-    /// See [`RingBuffer::with_chunks()`] for a way to make sure
-    /// that the second slice is always empty.
-    pub fn as_slices(&self) -> (&[T], &[T]) {
-        (
-            unsafe { core::slice::from_raw_parts(self.first_ptr, self.first_len) },
-            unsafe { core::slice::from_raw_parts(self.second_ptr, self.second_len) },
-        )
-    }
-
-    /// Drops the first `n` slots of the chunk, making the space available for writing again.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n` is greater than the number of slots in the chunk.
-    pub fn commit(self, n: usize) {
-        assert!(n <= self.len(), "cannot commit more than chunk size");
-        unsafe { self.commit_unchecked(n) };
-    }
-
-    /// Drops all slots that have been iterated, making the space available for writing again.
-    ///
-    /// Returns the number of iterated slots.
-    pub fn commit_iterated(self) -> usize {
-        let slots = self.iterated;
-        unsafe { self.commit_unchecked(slots) }
-    }
-
-    /// Drops all slots of the chunk, making the space available for writing again.
-    pub fn commit_all(self) {
-        let slots = self.len();
-        unsafe { self.commit_unchecked(slots) };
-    }
-
-    unsafe fn commit_unchecked(self, n: usize) -> usize {
-        let head = self.consumer.head.get();
-        // Safety: head has not yet been incremented
-        let ptr = self.consumer.buffer.slot_ptr(head);
-        let first_len = self.first_len.min(n);
-        for i in 0..first_len {
-            ptr.add(i).drop_in_place();
-        }
-        let ptr = self.consumer.buffer.data_ptr;
-        let second_len = self.second_len.min(n - first_len);
-        for i in 0..second_len {
-            ptr.add(i).drop_in_place();
-        }
-        let head = self.consumer.buffer.increment(head, n);
-        self.consumer.buffer.head.store(head, Ordering::Release);
-        self.consumer.head.set(head);
-        n
-    }
-
-    /// Returns the number of slots in the chunk.
-    pub fn len(&self) -> usize {
-        self.first_len + self.second_len
-    }
-
-    /// Returns `true` if the chunk contains no slots.
-    pub fn is_empty(&self) -> bool {
-        self.first_len == 0
-    }
-}
-
-impl<'a, T> Iterator for ReadChunk<'a, T> {
-    type Item = &'a T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let ptr = if self.iterated < self.first_len {
-            unsafe { self.first_ptr.add(self.iterated) }
-        } else if self.iterated < self.first_len + self.second_len {
-            unsafe { self.second_ptr.add(self.iterated - self.first_len) }
-        } else {
-            return None;
-        };
-        self.iterated += 1;
-        Some(unsafe { &*ptr })
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::io::Write for Producer<u8> {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        use ChunkError::TooFewSlots;
-        let mut chunk = match self.write_chunk_uninit(buf.len()) {
-            Ok(chunk) => chunk,
-            Err(TooFewSlots(0)) => return Err(std::io::ErrorKind::WouldBlock.into()),
-            Err(TooFewSlots(n)) => self.write_chunk_uninit(n).unwrap(),
-        };
-        let end = chunk.len();
-        let (first, second) = chunk.as_mut_slices();
-        let mid = first.len();
-        // NB: If buf.is_empty(), chunk will be empty as well and the following are no-ops:
-        buf[..mid].copy_to_uninit(first);
-        buf[mid..end].copy_to_uninit(second);
-        // Safety: All slots have been initialized
-        unsafe {
-            chunk.commit_all();
-        }
-        Ok(end)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        // Nothing to do here.
-        Ok(())
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::io::Read for Consumer<u8> {
-    #[inline]
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        use ChunkError::TooFewSlots;
-        let chunk = match self.read_chunk(buf.len()) {
-            Ok(chunk) => chunk,
-            Err(TooFewSlots(0)) => return Err(std::io::ErrorKind::WouldBlock.into()),
-            Err(TooFewSlots(n)) => self.read_chunk(n).unwrap(),
-        };
-        let (first, second) = chunk.as_slices();
-        let mid = first.len();
-        let end = chunk.len();
-        // NB: If buf.is_empty(), chunk will be empty as well and the following are no-ops:
-        buf[..mid].copy_from_slice(first);
-        buf[mid..end].copy_from_slice(second);
-        chunk.commit_all();
-        Ok(end)
     }
 }
 
@@ -1573,29 +851,6 @@ impl<T> fmt::Display for PushError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PushError::Full(_) => "full ring buffer".fmt(f),
-        }
-    }
-}
-
-/// Error type for [`Consumer::read_chunk()`], [`Producer::write_chunk()`]
-/// and [`Producer::write_chunk_uninit()`].
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ChunkError {
-    /// Fewer than the requested number of slots were available.
-    ///
-    /// Contains the number of slots that were available.
-    TooFewSlots(usize),
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for ChunkError {}
-
-impl fmt::Display for ChunkError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ChunkError::TooFewSlots(n) => {
-                alloc::format!("only {} slots available in ring buffer", n).fmt(f)
-            }
         }
     }
 }

--- a/tests/push_and_pop.rs
+++ b/tests/push_and_pop.rs
@@ -6,7 +6,7 @@ use rtrb::{chunks::ChunkError, RingBuffer};
 
 #[test]
 fn smoke() {
-    let (mut p, mut c) = RingBuffer::new(1).split();
+    let (mut p, mut c) = RingBuffer::new(1);
 
     p.push(7).unwrap();
     assert_eq!(c.pop(), Ok(7));
@@ -19,7 +19,7 @@ fn smoke() {
 #[test]
 fn capacity() {
     for i in 1..10 {
-        let (p, c) = RingBuffer::<i32>::new(i).split();
+        let (p, c) = RingBuffer::<i32>::new(i);
         assert_eq!(p.buffer().capacity(), i);
         assert_eq!(c.buffer().capacity(), i);
     }
@@ -27,7 +27,7 @@ fn capacity() {
 
 #[test]
 fn zero_capacity() {
-    let (mut p, mut c) = RingBuffer::<i32>::new(0).split();
+    let (mut p, mut c) = RingBuffer::<i32>::new(0);
 
     assert_eq!(p.slots(), 0);
     assert_eq!(c.slots(), 0);
@@ -65,7 +65,7 @@ fn zero_sized_type() {
     struct ZeroSized;
     assert_eq!(std::mem::size_of::<ZeroSized>(), 0);
 
-    let (mut p, mut c) = RingBuffer::new(1).split();
+    let (mut p, mut c) = RingBuffer::new(1);
     assert_eq!(p.buffer().capacity(), 1);
     assert_eq!(p.slots(), 1);
     assert_eq!(c.slots(), 0);
@@ -82,7 +82,7 @@ fn zero_sized_type() {
 #[test]
 fn parallel() {
     const COUNT: usize = 100_000;
-    let (mut p, mut c) = RingBuffer::new(3).split();
+    let (mut p, mut c) = RingBuffer::new(3);
     let pop_thread = std::thread::spawn(move || {
         for i in 0..COUNT {
             loop {
@@ -125,7 +125,7 @@ fn drops() {
         let additional = rng.gen_range(0, 50);
 
         DROPS.store(0, Ordering::SeqCst);
-        let (mut p, mut c) = RingBuffer::new(50).split();
+        let (mut p, mut c) = RingBuffer::new(50);
         let pop_thread = std::thread::spawn(move || {
             for _ in 0..steps {
                 while c.pop().is_err() {}

--- a/tests/push_and_pop.rs
+++ b/tests/push_and_pop.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rand::{thread_rng, Rng};
 
-use rtrb::{ChunkError, RingBuffer};
+use rtrb::{chunks::ChunkError, RingBuffer};
 
 #[test]
 fn smoke() {

--- a/tests/write_and_read.rs
+++ b/tests/write_and_read.rs
@@ -6,7 +6,7 @@ use rtrb::RingBuffer;
 
 #[test]
 fn write_and_read() {
-    let (mut p, mut c) = RingBuffer::new(2).split();
+    let (mut p, mut c) = RingBuffer::new(2);
     assert_eq!(p.write(&[10, 11]).unwrap(), 2);
 
     let mut buf = [0];
@@ -32,20 +32,20 @@ fn write_and_read() {
 
 #[test]
 fn write_empty_buf() {
-    let (mut p, _c) = RingBuffer::new(2).split();
+    let (mut p, _c) = RingBuffer::new(2);
     assert_eq!(p.write(&[]).unwrap(), 0);
 }
 
 #[test]
 fn read_empty_buf() {
-    let (mut p, mut c) = RingBuffer::new(2).split();
+    let (mut p, mut c) = RingBuffer::new(2);
     assert_eq!(p.push(99), Ok(()));
     assert_eq!(c.read(&mut []).unwrap(), 0);
 }
 
 #[test]
 fn write_error() {
-    let (mut p, _c) = RingBuffer::new(1).split();
+    let (mut p, _c) = RingBuffer::new(1);
     assert_eq!(p.push(10), Ok(()));
     assert_eq!(
         p.write(&[99]).unwrap_err().kind(),
@@ -55,7 +55,7 @@ fn write_error() {
 
 #[test]
 fn read_error() {
-    let (_p, mut c) = RingBuffer::new(1).split();
+    let (_p, mut c) = RingBuffer::new(1);
     let mut buf = [0];
     assert_eq!(
         c.read(&mut buf).unwrap_err().kind(),


### PR DESCRIPTION
This is a different potential way to go (compared to #52), which reduces the API surface instead of extending it.

This is a breaking change (mostly just removing `.split()`).

Auto-generated docs as ZIP file: https://github.com/mgeier/rtrb/suites/3125739092/artifacts/71657611.