### PR TITLE
Change iterator API to allow moving items in and out

### DIFF
--- a/benches/single_thread_single_byte.rs
+++ b/benches/single_thread_single_byte.rs
@@ -70,23 +70,13 @@ pub fn criterion_benchmark(criterion: &mut criterion::Criterion) {
 
     add_function(&mut group, "3-iterate-read", |i| {
         p.push(i).unwrap();
-        let mut chunk = c.read_chunk(1).unwrap();
-        let result = *(&mut chunk).next().unwrap();
-        chunk.commit_iterated();
-        result
+        let chunk = c.read_chunk(1).unwrap();
+        chunk.into_iter().next().unwrap()
     });
 
     add_function(&mut group, "3-iterate-write", |i| {
-        let mut chunk = p.write_chunk(1).unwrap();
-        *(&mut chunk).next().unwrap() = i;
-        chunk.commit_iterated();
-        c.pop().unwrap()
-    });
-
-    add_function(&mut group, "3-iterate-write-uninit", |i| {
-        let mut chunk = p.write_chunk_uninit(1).unwrap();
-        *(&mut chunk).next().unwrap() = MaybeUninit::new(i);
-        unsafe { chunk.commit_iterated() };
+        let chunk = p.write_chunk_uninit(1).unwrap();
+        chunk.populate(&mut std::iter::once(i));
         c.pop().unwrap()
     });
 

--- a/benches/single_thread_single_byte.rs
+++ b/benches/single_thread_single_byte.rs
@@ -76,7 +76,7 @@ pub fn criterion_benchmark(criterion: &mut criterion::Criterion) {
 
     add_function(&mut group, "3-iterate-write", |i| {
         let chunk = p.write_chunk_uninit(1).unwrap();
-        chunk.populate(&mut std::iter::once(i));
+        chunk.fill_from_iter(&mut std::iter::once(i));
         c.pop().unwrap()
     });
 

--- a/benches/single_thread_two_bytes.rs
+++ b/benches/single_thread_two_bytes.rs
@@ -110,7 +110,7 @@ pub fn criterion_benchmark(criterion: &mut criterion::Criterion) {
     add_function(&mut group, "3-iterate-write", |data| {
         let mut result = [0; 2];
         let chunk = p.write_chunk_uninit(data.len()).unwrap();
-        chunk.populate(&mut data.iter().copied());
+        chunk.fill_from_iter(&mut data.iter().copied());
         for i in result.iter_mut() {
             *i = c.pop().unwrap();
         }

--- a/benches/single_thread_with_chunks.rs
+++ b/benches/single_thread_with_chunks.rs
@@ -101,7 +101,7 @@ pub fn criterion_benchmark(criterion: &mut criterion::Criterion) {
     add_function(&mut group, "3-iterate-write", |data| {
         let mut result = [0; CHUNK_SIZE];
         let chunk = p.write_chunk_uninit(data.len()).unwrap();
-        chunk.populate(&mut data.iter().copied());
+        chunk.fill_from_iter(&mut data.iter().copied());
         let _ = c.read(&mut result).unwrap();
         result
     });

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -1,14 +1,20 @@
 //! Writing and reading multiple items at once into and from a [`RingBuffer`].
 //!
-//! Multiple items can be written at once by using [`Producer::write_chunk()`]
-//! or its `unsafe` (but probably slightly faster) cousin [`Producer::write_chunk_uninit()`].
+//! Multiple items at once can be moved from an iterator into the ring buffer by using
+//! [`Producer::write_chunk_uninit()`] and [`WriteChunkUninit::populate()`].
+//! Alternatively, mutable access to the (uninitialized) slots of the chunk can be obtained with
+//! [`WriteChunkUninit::as_mut_slices()`], which requires writing some `unsafe` code.
+//! To avoid that, [`Producer::write_chunk()`] can be used,
+//! which initializes all slots with their [`Default`] value
+//! and provides mutable access by means of [`WriteChunk::as_mut_slices()`].
 //!
-//! Multiple items can be read at once with [`Consumer::read_chunk()`].
+//! Multiple items at once can be moved out of the ring buffer by using
+//! [`Consumer::read_chunk()`] and iterating over the returned [`ReadChunk`]
+//! (or by explicitly calling [`ReadChunk::into_iter()`]).
+//! Immutable access to the slots of the chunk can be obtained with [`ReadChunk::as_slices()`].
 //!
 //! # Examples
 //!
-//! Producing and consuming multiple items at once with
-//! [`Producer::write_chunk()`] and [`Consumer::read_chunk()`], respectively.
 //! This example uses a single thread for simplicity, but in a real application,
 //! `producer` and `consumer` would of course live on different threads:
 //!
@@ -17,14 +23,9 @@
 //!
 //! let (mut producer, mut consumer) = RingBuffer::new(5);
 //!
-//! if let Ok(mut chunk) = producer.write_chunk(4) {
-//!     // NB: Don't use `chunk` as the first iterator in zip() if the other one might be shorter!
-//!     for (src, dst) in vec![10, 11, 12].into_iter().zip(&mut chunk) {
-//!         *dst = src;
-//!     }
-//!     // Don't forget to make the written slots available for reading!
-//!     chunk.commit_iterated();
-//!     // Note that we requested 4 slots but we've only written 3!
+//! if let Ok(chunk) = producer.write_chunk_uninit(4) {
+//!     chunk.populate([10, 11, 12]);
+//!     // Note that we requested 4 slots but we've only written to 3 of them!
 //! } else {
 //!     unreachable!();
 //! }
@@ -32,11 +33,8 @@
 //! assert_eq!(producer.slots(), 2);
 //! assert_eq!(consumer.slots(), 3);
 //!
-//! if let Ok(mut chunk) = consumer.read_chunk(2) {
-//!     // NB: Even though we are just reading, `chunk` needs to be mutable for iteration!
-//!     assert_eq!((&mut chunk).collect::<Vec<_>>(), [&10, &11]);
-//!     chunk.commit_iterated(); // Mark the slots as "consumed"
-//!     // chunk.commit_all() would also work here.
+//! if let Ok(chunk) = consumer.read_chunk(2) {
+//!     assert_eq!(chunk.into_iter().collect::<Vec<_>>(), [10, 11]);
 //! } else {
 //!     unreachable!();
 //! }
@@ -71,6 +69,37 @@
 //! assert!(consumer.is_empty());
 //! ```
 //!
+//! The iterator API can be used to move items from one ring buffer to another:
+//!
+//! ```
+//! use rtrb::{Consumer, Producer, chunks::ChunkError::TooFewSlots};
+//!
+//! fn move_at_most_n_items<T>(src: &mut Consumer<T>, dst: &mut Producer<T>, n: usize) -> usize {
+//!     let read_chunk = match src.read_chunk(n) {
+//!         Ok(chunk) => chunk,
+//!         // Optional optimization:
+//!         Err(TooFewSlots(0)) => return 0,
+//!         Err(TooFewSlots(n)) => src.read_chunk(n).unwrap(),
+//!     };
+//!     let write_chunk = match dst.write_chunk_uninit(read_chunk.len()) {
+//!         Ok(chunk) => chunk,
+//!         // Optional optimization:
+//!         Err(TooFewSlots(0)) => return 0,
+//!         Err(TooFewSlots(n)) => dst.write_chunk_uninit(n).unwrap(),
+//!     };
+//!     write_chunk.populate(read_chunk)
+//! }
+//! ```
+//!
+//! If the number of items should not be limited, a quick-and-dirty one-liner can be used:
+//!
+//! ```
+//! # use rtrb::{Consumer, Producer};
+//! fn move_items<T>(src: &mut Consumer<T>, dst: &mut Producer<T>) -> usize {
+//!     dst.write_chunk_uninit(dst.slots()).unwrap().populate(src.read_chunk(src.slots()).unwrap())
+//! }
+//! ```
+//!
 //! ## Common Access Patterns
 //!
 //! The following examples show the [`Producer`] side;
@@ -79,7 +108,8 @@
 //! which requires the trait bound `T: Default`.
 //! If that's too restrictive or if you want to squeeze out the last bit of performance,
 //! you can use [`Producer::write_chunk_uninit()`] instead,
-//! but this will force you to write some `unsafe` code.
+//! but this will force you to write some `unsafe` code
+//! (except when using [`WriteChunkUninit::populate()`]).
 //!
 //! Copy a whole slice of items into the ring buffer, but only if space permits
 //! (if not, the input slice is returned as an error):
@@ -137,26 +167,24 @@
 //! ```
 //! use rtrb::{Producer, chunks::ChunkError::TooFewSlots};
 //!
-//! fn push_from_iter<T, I>(queue: &mut Producer<T>, iter: &mut I) -> usize
+//! fn push_from_iter<T, I>(queue: &mut Producer<T>, iter: I) -> usize
 //! where
 //!     T: Default,
-//!     I: Iterator<Item = T>,
+//!     I: IntoIterator<Item = T>,
 //! {
+//!     let iter = iter.into_iter();
 //!     let n = match iter.size_hint() {
 //!         (_, None) => queue.slots(),
 //!         (_, Some(n)) => n,
 //!     };
-//!     let mut chunk = match queue.write_chunk(n) {
+//!     let chunk = match queue.write_chunk_uninit(n) {
 //!         Ok(chunk) => chunk,
 //!         // As above, this is an optional optimization:
 //!         Err(TooFewSlots(0)) => return 0,
 //!         // As above, this will always succeed:
-//!         Err(TooFewSlots(n)) => queue.write_chunk(n).unwrap(),
+//!         Err(TooFewSlots(n)) => queue.write_chunk_uninit(n).unwrap(),
 //!     };
-//!     for (source, target) in iter.zip(&mut chunk) {
-//!         *target = source;
-//!     }
-//!     chunk.commit_iterated()
+//!     chunk.populate(iter)
 //! }
 //! ```
 
@@ -175,24 +203,22 @@ impl<T> Producer<T> {
     ///
     /// If not enough slots are available, an error
     /// (containing the number of available slots) is returned.
+    /// Use [`Producer::slots()`] to obtain the number of available slots beforehand.
     ///
-    /// The elements can be accessed with [`WriteChunk::as_mut_slices()`] or
-    /// by iterating over (a `&mut` to) the [`WriteChunk`].
+    /// [`WriteChunk::as_mut_slices()`] provides mutable access to the slots.
+    /// After writing to those slots, they explicitly have to be made available
+    /// to be read by the [`Consumer`] by calling [`WriteChunk::commit()`]
+    /// or [`WriteChunk::commit_all()`].
     ///
-    /// The provided slots are *not* automatically made available
-    /// to be read by the [`Consumer`].
-    /// This has to be explicitly done by calling [`WriteChunk::commit()`],
-    /// [`WriteChunk::commit_iterated()`] or [`WriteChunk::commit_all()`].
-    /// If items are written but *not* committed afterwards,
-    /// they will *not* become available for reading and
-    /// they will be leaked (which is only relevant if `T` implements [`Drop`]).
-    ///
-    /// For an unsafe alternative that has no restrictions on `T`,
+    /// For an alternative that does not require the trait bound [`Default`],
     /// see [`Producer::write_chunk_uninit()`].
+    ///
+    /// If items are supposed to be moved from an iterator into the ring buffer,
+    /// [`Producer::write_chunk_uninit()`] and [`WriteChunkUninit::populate()`] can be used.
     ///
     /// # Examples
     ///
-    /// See the documentation of the [`chunks`](crate::chunks#examples) module for more examples.
+    /// See the documentation of the [`chunks`](crate::chunks#examples) module.
     pub fn write_chunk(&mut self, n: usize) -> Result<WriteChunk<'_, T>, ChunkError>
     where
         T: Default,
@@ -204,25 +230,26 @@ impl<T> Producer<T> {
     ///
     /// If not enough slots are available, an error
     /// (containing the number of available slots) is returned.
+    /// Use [`Producer::slots()`] to obtain the number of available slots beforehand.
     ///
-    /// The elements can be accessed with [`WriteChunkUninit::as_mut_slices()`] or
-    /// by iterating over (a `&mut` to) the [`WriteChunkUninit`].
+    /// [`WriteChunkUninit::as_mut_slices()`] provides mutable access
+    /// to the uninitialized slots.
+    /// After writing to those slots, they explicitly have to be made available
+    /// to be read by the [`Consumer`] by calling [`WriteChunkUninit::commit()`]
+    /// or [`WriteChunkUninit::commit_all()`].
     ///
-    /// The provided slots are *not* automatically made available
-    /// to be read by the [`Consumer`].
-    /// This has to be explicitly done by calling [`WriteChunkUninit::commit()`],
-    /// [`WriteChunkUninit::commit_iterated()`] or
-    /// [`WriteChunkUninit::commit_all()`].
-    /// If items are written but *not* committed afterwards,
-    /// they will *not* become available for reading and
-    /// they will be leaked (which is only relevant if `T` implements [`Drop`]).
+    /// Alternatively, [`WriteChunkUninit::populate()`] can be used
+    /// to move items from an iterator into the available slots.
+    /// All moved items are automatically made available to be read by the [`Consumer`].
     ///
     /// # Safety
     ///
-    /// This function itself is safe, but accessing the returned slots might not be,
-    /// as well as invoking some methods of [`WriteChunkUninit`].
+    /// This function itself is safe, as is [`WriteChunkUninit::populate()`].
+    /// However, when using [`WriteChunkUninit::as_mut_slices()`],
+    /// the user has to make sure that the relevant slots have been initialized
+    /// before calling [`WriteChunkUninit::commit()`] or [`WriteChunkUninit::commit_all()`].
     ///
-    /// For a safe alternative that provides [`Default`]-initialized slots,
+    /// For a safe alternative that provides mutable slices of [`Default`]-initialized slots,
     /// see [`Producer::write_chunk()`].
     pub fn write_chunk_uninit(&mut self, n: usize) -> Result<WriteChunkUninit<'_, T>, ChunkError> {
         let tail = self.tail.get();
@@ -247,7 +274,6 @@ impl<T> Producer<T> {
             second_ptr: self.buffer.data_ptr,
             second_len: n - first_len,
             producer: self,
-            iterated: 0,
         })
     }
 }
@@ -257,17 +283,320 @@ impl<T> Consumer<T> {
     ///
     /// If not enough slots are available, an error
     /// (containing the number of available slots) is returned.
+    /// Use [`Consumer::slots()`] to obtain the number of available slots beforehand.
     ///
-    /// The elements can be accessed with [`ReadChunk::as_slices()`] or
-    /// by iterating over (a `&mut` to) the [`ReadChunk`].
+    /// [`ReadChunk::as_slices()`] provides immutable access to the slots.
+    /// After reading from those slots, they explicitly have to be made available
+    /// to be written again by the [`Producer`] by calling [`ReadChunk::commit()`]
+    /// or [`ReadChunk::commit_all()`].
+    ///
+    /// Alternatively, items can be moved out of the [`ReadChunk`] using iteration
+    /// because it implements [`IntoIterator`]
+    /// ([`ReadChunk::into_iter()`] can be used to explicitly turn it into an [`Iterator`]).
+    /// All moved items are automatically made available to be written again by the [`Producer`].
+    ///
+    /// # Examples
+    ///
+    /// See the documentation of the [`chunks`](crate::chunks#examples) module.
+    pub fn read_chunk(&mut self, n: usize) -> Result<ReadChunk<'_, T>, ChunkError> {
+        let head = self.head.get();
+
+        // Check if the queue has *possibly* not enough slots.
+        if self.buffer.distance(head, self.tail.get()) < n {
+            // Refresh the tail ...
+            let tail = self.buffer.tail.load(Ordering::Acquire);
+            self.tail.set(tail);
+
+            // ... and check if there *really* are not enough slots.
+            let slots = self.buffer.distance(head, tail);
+            if slots < n {
+                return Err(ChunkError::TooFewSlots(slots));
+            }
+        }
+
+        let head = self.buffer.collapse_position(head);
+        let first_len = n.min(self.buffer.capacity - head);
+        Ok(ReadChunk {
+            first_ptr: unsafe { self.buffer.data_ptr.add(head) },
+            first_len,
+            second_ptr: self.buffer.data_ptr,
+            second_len: n - first_len,
+            consumer: self,
+        })
+    }
+}
+
+/// Structure for writing into multiple ([`Default`]-initialized) slots in one go.
+///
+/// This is returned from [`Producer::write_chunk()`].
+///
+/// To obtain uninitialized slots, use [`Producer::write_chunk_uninit()`] instead,
+/// which also allows moving items from an iterator into the ring buffer
+/// by means of [`WriteChunkUninit::populate()`].
+#[derive(Debug, PartialEq, Eq)]
+pub struct WriteChunk<'a, T>(WriteChunkUninit<'a, T>);
+
+impl<'a, T> From<WriteChunkUninit<'a, T>> for WriteChunk<'a, T>
+where
+    T: Default,
+{
+    /// Fills all slots with the [`Default`] value.
+    fn from(chunk: WriteChunkUninit<'a, T>) -> Self {
+        for i in 0..chunk.first_len {
+            unsafe {
+                chunk.first_ptr.add(i).write(Default::default());
+            }
+        }
+        for i in 0..chunk.second_len {
+            unsafe {
+                chunk.second_ptr.add(i).write(Default::default());
+            }
+        }
+        WriteChunk(chunk)
+    }
+}
+
+impl<T> WriteChunk<'_, T>
+where
+    T: Default,
+{
+    /// Returns two slices for writing to the requested slots.
+    ///
+    /// All slots are initially filled with their [`Default`] value.
+    ///
+    /// The first slice can only be empty if `0` slots have been requested.
+    /// If the first slice contains all requested slots, the second one is empty.
+    ///
+    /// After writing to the slots, they are *not* automatically made available
+    /// to be read by the [`Consumer`].
+    /// This has to be explicitly done by calling [`commit()`](WriteChunk::commit)
+    /// or [`commit_all()`](WriteChunk::commit_all).
+    /// If items are written but *not* committed afterwards,
+    /// they will *not* become available for reading and
+    /// they will be leaked (which is only relevant if `T` implements [`Drop`]).
+    pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
+        // Safety: All slots have been initialized in From::from().
+        unsafe {
+            (
+                core::slice::from_raw_parts_mut(self.0.first_ptr, self.0.first_len),
+                core::slice::from_raw_parts_mut(self.0.second_ptr, self.0.second_len),
+            )
+        }
+    }
+
+    /// Makes the first `n` slots of the chunk available for reading.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is greater than the number of slots in the chunk.
+    pub fn commit(self, n: usize) {
+        // Safety: All slots have been initialized in From::from() and there are no destructors.
+        unsafe { self.0.commit(n) }
+    }
+
+    /// Makes the whole chunk available for reading.
+    pub fn commit_all(self) {
+        // Safety: All slots have been initialized in From::from().
+        unsafe { self.0.commit_all() }
+    }
+
+    /// Returns the number of slots in the chunk.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the chunk contains no slots.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Structure for writing into multiple (uninitialized) slots in one go.
+///
+/// This is returned from [`Producer::write_chunk_uninit()`].
+#[derive(Debug, PartialEq, Eq)]
+pub struct WriteChunkUninit<'a, T> {
+    first_ptr: *mut T,
+    first_len: usize,
+    second_ptr: *mut T,
+    second_len: usize,
+    producer: &'a Producer<T>,
+}
+
+impl<T> WriteChunkUninit<'_, T> {
+    /// Returns two slices for writing to the requested slots.
+    ///
+    /// The first slice can only be empty if `0` slots have been requested.
+    /// If the first slice contains all requested slots, the second one is empty.
+    ///
+    /// The extension trait [`CopyToUninit`] can be used to safely copy data into those slices.
+    ///
+    /// After writing to the slots, they are *not* automatically made available
+    /// to be read by the [`Consumer`].
+    /// This has to be explicitly done by calling [`commit()`](WriteChunkUninit::commit)
+    /// or [`commit_all()`](WriteChunkUninit::commit_all).
+    /// If items are written but *not* committed afterwards,
+    /// they will *not* become available for reading and
+    /// they will be leaked (which is only relevant if `T` implements [`Drop`]).
+    pub fn as_mut_slices(&mut self) -> (&mut [MaybeUninit<T>], &mut [MaybeUninit<T>]) {
+        unsafe {
+            (
+                core::slice::from_raw_parts_mut(self.first_ptr as *mut _, self.first_len),
+                core::slice::from_raw_parts_mut(self.second_ptr as *mut _, self.second_len),
+            )
+        }
+    }
+
+    /// Makes the first `n` slots of the chunk available for reading.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is greater than the number of slots in the chunk.
+    ///
+    /// # Safety
+    ///
+    /// The user must make sure that the first `n` elements have been initialized.
+    pub unsafe fn commit(self, n: usize) {
+        assert!(n <= self.len(), "cannot commit more than chunk size");
+        self.commit_unchecked(n);
+    }
+
+    /// Makes the whole chunk available for reading.
+    ///
+    /// # Safety
+    ///
+    /// The user must make sure that all elements have been initialized.
+    pub unsafe fn commit_all(self) {
+        let slots = self.len();
+        self.commit_unchecked(slots);
+    }
+
+    unsafe fn commit_unchecked(self, n: usize) -> usize {
+        let tail = self.producer.buffer.increment(self.producer.tail.get(), n);
+        self.producer.buffer.tail.store(tail, Ordering::Release);
+        self.producer.tail.set(tail);
+        n
+    }
+
+    /// Moves items from an iterator into the (uninitialized) slots of the chunk.
+    ///
+    /// The number of moved items is returned.
+    ///
+    /// All moved items are automatically made availabe to be read by the [`Consumer`].
+    ///
+    /// # Examples
+    ///
+    /// If the iterator contains too few items, only a part of the chunk
+    /// is made available for reading:
+    ///
+    /// ```
+    /// use rtrb::{RingBuffer, PopError};
+    ///
+    /// let (mut p, mut c) = RingBuffer::new(4);
+    ///
+    /// if let Ok(chunk) = p.write_chunk_uninit(3) {
+    ///     assert_eq!(chunk.populate([10, 20]), 2);
+    /// } else {
+    ///     unreachable!();
+    /// }
+    /// assert_eq!(p.slots(), 2);
+    /// assert_eq!(c.pop(), Ok(10));
+    /// assert_eq!(c.pop(), Ok(20));
+    /// assert_eq!(c.pop(), Err(PopError::Empty));
+    /// ```
+    ///
+    /// If the chunk size is too small, some items may remain in the iterator.
+    /// To be able to keep using the iterator after the call,
+    /// `&mut` (or [`Iterator::by_ref()`]) can be used.
+    ///
+    /// ```
+    /// use rtrb::{RingBuffer, PopError};
+    ///
+    /// let (mut p, mut c) = RingBuffer::new(4);
+    ///
+    /// let mut it = vec![10, 20, 30].into_iter();
+    /// if let Ok(chunk) = p.write_chunk_uninit(2) {
+    ///     assert_eq!(chunk.populate(&mut it), 2);
+    /// } else {
+    ///     unreachable!();
+    /// }
+    /// assert_eq!(c.pop(), Ok(10));
+    /// assert_eq!(c.pop(), Ok(20));
+    /// assert_eq!(c.pop(), Err(PopError::Empty));
+    /// assert_eq!(it.next(), Some(30));
+    /// ```
+    pub fn populate<I>(self, iter: I) -> usize
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut iter = iter.into_iter();
+        let mut iterated = 0;
+        'outer: for &(ptr, len) in &[
+            (self.first_ptr, self.first_len),
+            (self.second_ptr, self.second_len),
+        ] {
+            for i in 0..len {
+                match iter.next() {
+                    Some(item) => {
+                        // Safety: It is allowed to write to this memory slot
+                        unsafe { ptr.add(i).write(item) };
+                        iterated += 1;
+                    }
+                    None => break 'outer,
+                }
+            }
+        }
+        // Safety: iterated slots have been initialized above
+        unsafe { self.commit_unchecked(iterated) }
+    }
+
+    /// Returns the number of slots in the chunk.
+    pub fn len(&self) -> usize {
+        self.first_len + self.second_len
+    }
+
+    /// Returns `true` if the chunk contains no slots.
+    pub fn is_empty(&self) -> bool {
+        self.first_len == 0
+    }
+}
+
+/// Structure for reading from multiple slots in one go.
+///
+/// This is returned from [`Consumer::read_chunk()`].
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReadChunk<'a, T> {
+    first_ptr: *const T,
+    first_len: usize,
+    second_ptr: *const T,
+    second_len: usize,
+    consumer: &'a mut Consumer<T>,
+}
+
+impl<T> ReadChunk<'_, T> {
+    /// Returns two slices for reading from the requested slots.
+    ///
+    /// The first slice can only be empty if `0` slots have been requested.
+    /// If the first slice contains all requested slots, the second one is empty.
     ///
     /// The provided slots are *not* automatically made available
     /// to be written again by the [`Producer`].
-    /// This has to be explicitly done by calling [`ReadChunk::commit()`],
-    /// [`ReadChunk::commit_iterated()`] or [`ReadChunk::commit_all()`].
+    /// This has to be explicitly done by calling [`commit()`](ReadChunk::commit)
+    /// or [`commit_all()`](ReadChunk::commit_all).
     /// Note that this runs the destructor of the committed items (if `T` implements [`Drop`]).
-    /// You can "peek" at the contained values by simply
-    /// not calling any of the "commit" methods.
+    /// You can "peek" at the contained values by simply not calling any of the "commit" methods.
+    pub fn as_slices(&self) -> (&[T], &[T]) {
+        (
+            unsafe { core::slice::from_raw_parts(self.first_ptr, self.first_len) },
+            unsafe { core::slice::from_raw_parts(self.second_ptr, self.second_len) },
+        )
+    }
+
+    /// Drops the first `n` slots of the chunk, making the space available for writing again.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is greater than the number of slots in the chunk.
     ///
     /// # Examples
     ///
@@ -315,322 +644,9 @@ impl<T> Consumer<T> {
     /// // ... and it is dropped when the ring buffer goes out of scope:
     /// assert_eq!(unsafe { DROP_COUNT }, 3);
     /// ```
-    ///
-    /// See the documentation of the [`chunks`](crate::chunks#examples) module for more examples.
-    pub fn read_chunk(&mut self, n: usize) -> Result<ReadChunk<'_, T>, ChunkError> {
-        let head = self.head.get();
-
-        // Check if the queue has *possibly* not enough slots.
-        if self.buffer.distance(head, self.tail.get()) < n {
-            // Refresh the tail ...
-            let tail = self.buffer.tail.load(Ordering::Acquire);
-            self.tail.set(tail);
-
-            // ... and check if there *really* are not enough slots.
-            let slots = self.buffer.distance(head, tail);
-            if slots < n {
-                return Err(ChunkError::TooFewSlots(slots));
-            }
-        }
-
-        let head = self.buffer.collapse_position(head);
-        let first_len = n.min(self.buffer.capacity - head);
-        Ok(ReadChunk {
-            first_ptr: unsafe { self.buffer.data_ptr.add(head) },
-            first_len,
-            second_ptr: self.buffer.data_ptr,
-            second_len: n - first_len,
-            consumer: self,
-            iterated: 0,
-        })
-    }
-}
-
-/// Structure for writing into multiple ([`Default`]-initialized) slots in one go.
-///
-/// This is returned from [`Producer::write_chunk()`].
-///
-/// For an unsafe alternative that provides uninitialized slots,
-/// see [`WriteChunkUninit`].
-///
-/// The slots (which initially contain [`Default`] values) can be accessed with
-/// [`as_mut_slices()`](WriteChunk::as_mut_slices)
-/// or by iteration, which yields mutable references (in other words: `&mut T`).
-/// A mutable reference (`&mut`) to the `WriteChunk`
-/// should be used to iterate over it.
-/// Each slot can only be iterated once and the number of iterations is tracked.
-///
-/// After writing, the provided slots are *not* automatically made available
-/// to be read by the [`Consumer`].
-/// If desired, this has to be explicitly done by calling
-/// [`commit()`](WriteChunk::commit),
-/// [`commit_iterated()`](WriteChunk::commit_iterated) or
-/// [`commit_all()`](WriteChunk::commit_all).
-/// If items are written but *not* committed afterwards,
-/// they will *not* become available for reading and
-/// they will be leaked (which is only relevant if `T` implements [`Drop`]).
-#[derive(Debug, PartialEq, Eq)]
-pub struct WriteChunk<'a, T>(WriteChunkUninit<'a, T>);
-
-impl<'a, T> From<WriteChunkUninit<'a, T>> for WriteChunk<'a, T>
-where
-    T: Default,
-{
-    /// Fills all slots with the [`Default`] value.
-    fn from(chunk: WriteChunkUninit<'a, T>) -> Self {
-        for i in 0..chunk.first_len {
-            unsafe {
-                chunk.first_ptr.add(i).write(Default::default());
-            }
-        }
-        for i in 0..chunk.second_len {
-            unsafe {
-                chunk.second_ptr.add(i).write(Default::default());
-            }
-        }
-        WriteChunk(chunk)
-    }
-}
-
-impl<T> WriteChunk<'_, T>
-where
-    T: Default,
-{
-    /// Returns two slices for writing to the requested slots.
-    ///
-    /// All slots are initially filled with their [`Default`] value.
-    ///
-    /// The first slice can only be empty if `0` slots have been requested.
-    /// If the first slice contains all requested slots, the second one is empty.
-    pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
-        // Safety: All slots have been initialized in From::from().
-        unsafe {
-            (
-                core::slice::from_raw_parts_mut(self.0.first_ptr, self.0.first_len),
-                core::slice::from_raw_parts_mut(self.0.second_ptr, self.0.second_len),
-            )
-        }
-    }
-
-    /// Makes the first `n` slots of the chunk available for reading.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n` is greater than the number of slots in the chunk.
-    pub fn commit(self, n: usize) {
-        // Safety: All slots have been initialized in From::from() and there are no destructors.
-        unsafe { self.0.commit(n) }
-    }
-
-    /// Returns the number of iterated slots and makes them available for reading.
-    pub fn commit_iterated(self) -> usize {
-        // Safety: All slots have been initialized in From::from() and there are no destructors.
-        unsafe { self.0.commit_iterated() }
-    }
-
-    /// Makes the whole chunk available for reading.
-    pub fn commit_all(self) {
-        // Safety: All slots have been initialized in From::from().
-        unsafe { self.0.commit_all() }
-    }
-
-    /// Returns the number of slots in the chunk.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns `true` if the chunk contains no slots.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl<'a, T> Iterator for WriteChunk<'a, T>
-where
-    T: Default,
-{
-    type Item = &'a mut T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|item| {
-            // Safety: All slots have been initialized in From::from().
-            unsafe { &mut *item.as_mut_ptr() }
-        })
-    }
-}
-
-/// Structure for writing into multiple (uninitialized) slots in one go.
-///
-/// This is returned from [`Producer::write_chunk_uninit()`].
-///
-/// For a safe alternative that provides [`Default`]-initialized slots, see [`WriteChunk`].
-///
-/// The slots can be accessed with
-/// [`as_mut_slices()`](WriteChunkUninit::as_mut_slices)
-/// or by iteration, which yields mutable references to possibly uninitialized data
-/// (in other words: `&mut MaybeUninit<T>`).
-/// A mutable reference (`&mut`) to the `WriteChunkUninit`
-/// should be used to iterate over it.
-/// Each slot can only be iterated once and the number of iterations is tracked.
-///
-/// After writing, the provided slots are *not* automatically made available
-/// to be read by the [`Consumer`].
-/// If desired, this has to be explicitly done by calling
-/// [`commit()`](WriteChunkUninit::commit),
-/// [`commit_iterated()`](WriteChunkUninit::commit_iterated) or
-/// [`commit_all()`](WriteChunkUninit::commit_all).
-/// If items are written but *not* committed afterwards,
-/// they will *not* become available for reading and
-/// they will be leaked (which is only relevant if `T` implements [`Drop`]).
-#[derive(Debug, PartialEq, Eq)]
-pub struct WriteChunkUninit<'a, T> {
-    first_ptr: *mut T,
-    first_len: usize,
-    second_ptr: *mut T,
-    second_len: usize,
-    producer: &'a Producer<T>,
-    iterated: usize,
-}
-
-impl<T> WriteChunkUninit<'_, T> {
-    /// Returns two slices for writing to the requested slots.
-    ///
-    /// The first slice can only be empty if `0` slots have been requested.
-    /// If the first slice contains all requested slots, the second one is empty.
-    ///
-    /// The extension trait [`CopyToUninit`] can be used to safely copy data into those slices.
-    pub fn as_mut_slices(&mut self) -> (&mut [MaybeUninit<T>], &mut [MaybeUninit<T>]) {
-        unsafe {
-            (
-                core::slice::from_raw_parts_mut(self.first_ptr as *mut _, self.first_len),
-                core::slice::from_raw_parts_mut(self.second_ptr as *mut _, self.second_len),
-            )
-        }
-    }
-
-    /// Makes the first `n` slots of the chunk available for reading.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n` is greater than the number of slots in the chunk.
-    ///
-    /// # Safety
-    ///
-    /// The user must make sure that the first `n` elements
-    /// (and not more, in case `T` implements [`Drop`]) have been initialized.
-    pub unsafe fn commit(self, n: usize) {
-        assert!(n <= self.len(), "cannot commit more than chunk size");
-        self.commit_unchecked(n);
-    }
-
-    /// Returns the number of iterated slots and makes them available for reading.
-    ///
-    /// # Safety
-    ///
-    /// The user must make sure that all iterated elements have been initialized.
-    pub unsafe fn commit_iterated(self) -> usize {
-        let slots = self.iterated;
-        self.commit_unchecked(slots)
-    }
-
-    /// Makes the whole chunk available for reading.
-    ///
-    /// # Safety
-    ///
-    /// The user must make sure that all elements have been initialized.
-    pub unsafe fn commit_all(self) {
-        let slots = self.len();
-        self.commit_unchecked(slots);
-    }
-
-    unsafe fn commit_unchecked(self, n: usize) -> usize {
-        let tail = self.producer.buffer.increment(self.producer.tail.get(), n);
-        self.producer.buffer.tail.store(tail, Ordering::Release);
-        self.producer.tail.set(tail);
-        n
-    }
-
-    /// Returns the number of slots in the chunk.
-    pub fn len(&self) -> usize {
-        self.first_len + self.second_len
-    }
-
-    /// Returns `true` if the chunk contains no slots.
-    pub fn is_empty(&self) -> bool {
-        self.first_len == 0
-    }
-}
-
-impl<'a, T> Iterator for WriteChunkUninit<'a, T> {
-    type Item = &'a mut MaybeUninit<T>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let ptr = if self.iterated < self.first_len {
-            unsafe { self.first_ptr.add(self.iterated) }
-        } else if self.iterated < self.first_len + self.second_len {
-            unsafe { self.second_ptr.add(self.iterated - self.first_len) }
-        } else {
-            return None;
-        };
-        self.iterated += 1;
-        Some(unsafe { &mut *(ptr as *mut _) })
-    }
-}
-
-/// Structure for reading from multiple slots in one go.
-///
-/// This is returned from [`Consumer::read_chunk()`].
-///
-/// The slots can be accessed with [`as_slices()`](ReadChunk::as_slices)
-/// or by iteration.
-/// Even though iterating yields immutable references (`&T`),
-/// a mutable reference (`&mut`) to the `ReadChunk` should be used to iterate over it.
-/// Each slot can only be iterated once and the number of iterations is tracked.
-///
-/// After reading, the provided slots are *not* automatically made available
-/// to be written again by the [`Producer`].
-/// If desired, this has to be explicitly done by calling [`commit()`](ReadChunk::commit),
-/// [`commit_iterated()`](ReadChunk::commit_iterated) or [`commit_all()`](ReadChunk::commit_all).
-/// Note that this runs the destructor of the committed items (if `T` implements [`Drop`]).
-/// You can "peek" at the contained values by simply not calling any of the "commit" methods.
-#[derive(Debug, PartialEq, Eq)]
-pub struct ReadChunk<'a, T> {
-    first_ptr: *const T,
-    first_len: usize,
-    second_ptr: *const T,
-    second_len: usize,
-    consumer: &'a mut Consumer<T>,
-    iterated: usize,
-}
-
-impl<T> ReadChunk<'_, T> {
-    /// Returns two slices for reading from the requested slots.
-    ///
-    /// The first slice can only be empty if `0` slots have been requested.
-    /// If the first slice contains all requested slots, the second one is empty.
-    pub fn as_slices(&self) -> (&[T], &[T]) {
-        (
-            unsafe { core::slice::from_raw_parts(self.first_ptr, self.first_len) },
-            unsafe { core::slice::from_raw_parts(self.second_ptr, self.second_len) },
-        )
-    }
-
-    /// Drops the first `n` slots of the chunk, making the space available for writing again.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n` is greater than the number of slots in the chunk.
     pub fn commit(self, n: usize) {
         assert!(n <= self.len(), "cannot commit more than chunk size");
         unsafe { self.commit_unchecked(n) };
-    }
-
-    /// Drops all slots that have been iterated, making the space available for writing again.
-    ///
-    /// Returns the number of iterated slots.
-    pub fn commit_iterated(self) -> usize {
-        let slots = self.iterated;
-        unsafe { self.commit_unchecked(slots) }
     }
 
     /// Drops all slots of the chunk, making the space available for writing again.
@@ -669,21 +685,76 @@ impl<T> ReadChunk<'_, T> {
     }
 }
 
-impl<'a, T> Iterator for ReadChunk<'a, T> {
-    type Item = &'a T;
+impl<'a, T> IntoIterator for ReadChunk<'a, T> {
+    type Item = T;
+    type IntoIter = ReadChunkIntoIter<'a, T>;
+
+    /// Turns a [`ReadChunk`] into an iterator.
+    ///
+    /// When the iterator is dropped, all iterated slots are made available for writing again.
+    /// Non-iterated items remain in the ring buffer.
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter {
+            chunk: self,
+            iterated: 0,
+        }
+    }
+}
+
+/// An iterator that moves out of a [`ReadChunk`].
+///
+/// This `struct` is created by the [`into_iter()`](ReadChunk::into_iter) method
+/// on [`ReadChunk`] (provided by the [`IntoIterator`] trait).
+///
+/// When this `struct` is dropped, the iterated slots are made available for writing again.
+/// Non-iterated items remain in the ring buffer.
+pub struct ReadChunkIntoIter<'a, T> {
+    chunk: ReadChunk<'a, T>,
+    iterated: usize,
+}
+
+impl<'a, T> Drop for ReadChunkIntoIter<'a, T> {
+    /// Makes all iterated slots available for writing again.
+    ///
+    /// Non-iterated items remain in the ring buffer and are *not* dropped.
+    fn drop(&mut self) {
+        let consumer = &self.chunk.consumer;
+        let head = consumer
+            .buffer
+            .increment(consumer.head.get(), self.iterated);
+        consumer.buffer.head.store(head, Ordering::Release);
+        consumer.head.set(head);
+    }
+}
+
+impl<'a, T> Iterator for ReadChunkIntoIter<'a, T> {
+    type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let ptr = if self.iterated < self.first_len {
-            unsafe { self.first_ptr.add(self.iterated) }
-        } else if self.iterated < self.first_len + self.second_len {
-            unsafe { self.second_ptr.add(self.iterated - self.first_len) }
+        let ptr = if self.iterated < self.chunk.first_len {
+            unsafe { self.chunk.first_ptr.add(self.iterated) }
+        } else if self.iterated < self.chunk.first_len + self.chunk.second_len {
+            unsafe {
+                self.chunk
+                    .second_ptr
+                    .add(self.iterated - self.chunk.first_len)
+            }
         } else {
             return None;
         };
         self.iterated += 1;
-        Some(unsafe { &*ptr })
+        Some(unsafe { ptr.read() })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.chunk.first_len + self.chunk.second_len - self.iterated;
+        (remaining, Some(remaining))
     }
 }
+
+impl<'a, T> ExactSizeIterator for ReadChunkIntoIter<'a, T> {}
+
+impl<'a, T> core::iter::FusedIterator for ReadChunkIntoIter<'a, T> {}
 
 #[cfg(feature = "std")]
 impl std::io::Write for Producer<u8> {

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -72,32 +72,11 @@
 //! The iterator API can be used to move items from one ring buffer to another:
 //!
 //! ```
-//! use rtrb::{Consumer, Producer, chunks::ChunkError::TooFewSlots};
+//! use rtrb::{Consumer, Producer};
 //!
-//! fn move_at_most_n_items<T>(src: &mut Consumer<T>, dst: &mut Producer<T>, n: usize) -> usize {
-//!     let read_chunk = match src.read_chunk(n) {
-//!         Ok(chunk) => chunk,
-//!         // Optional optimization:
-//!         Err(TooFewSlots(0)) => return 0,
-//!         Err(TooFewSlots(n)) => src.read_chunk(n).unwrap(),
-//!     };
-//!     let write_chunk = match dst.write_chunk_uninit(read_chunk.len()) {
-//!         Ok(chunk) => chunk,
-//!         // Optional optimization:
-//!         Err(TooFewSlots(0)) => return 0,
-//!         Err(TooFewSlots(n)) => dst.write_chunk_uninit(n).unwrap(),
-//!     };
-//!     write_chunk.fill_from_iter(read_chunk)
-//! }
-//! ```
-//!
-//! If the number of items should not be limited, a quick-and-dirty one-liner can be used:
-//!
-//! ```
-//! # use rtrb::{Consumer, Producer};
 //! fn move_items<T>(src: &mut Consumer<T>, dst: &mut Producer<T>) -> usize {
-//!
-//!     dst.write_chunk_uninit(dst.slots()).unwrap().fill_from_iter(src.read_chunk(src.slots()).unwrap())
+//!     let n = src.slots().min(dst.slots());
+//!     dst.write_chunk_uninit(n).unwrap().fill_from_iter(src.read_chunk(n).unwrap())
 //! }
 //! ```
 //!

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -1,7 +1,7 @@
 //! Writing and reading multiple items at once into and from a [`RingBuffer`].
 //!
 //! Multiple items at once can be moved from an iterator into the ring buffer by using
-//! [`Producer::write_chunk_uninit()`] and [`WriteChunkUninit::fill_from_iter()`].
+//! [`Producer::write_chunk_uninit()`] followed by [`WriteChunkUninit::fill_from_iter()`].
 //! Alternatively, mutable access to the (uninitialized) slots of the chunk can be obtained with
 //! [`WriteChunkUninit::as_mut_slices()`], which requires writing some `unsafe` code.
 //! To avoid that, [`Producer::write_chunk()`] can be used,
@@ -194,7 +194,8 @@ impl<T> Producer<T> {
     /// see [`Producer::write_chunk_uninit()`].
     ///
     /// If items are supposed to be moved from an iterator into the ring buffer,
-    /// [`Producer::write_chunk_uninit()`] and [`WriteChunkUninit::fill_from_iter()`] can be used.
+    /// [`Producer::write_chunk_uninit()`] followed by [`WriteChunkUninit::fill_from_iter()`]
+    /// can be used.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,7 +466,7 @@ impl<T> Producer<T> {
 /// Individual elements can be moved out of the ring buffer with [`Consumer::pop()`],
 /// multiple elements at once can be read with [`Consumer::read_chunk()`].
 ///
-/// The number of free slots currently available for reading can be obtained with
+/// The number of slots currently available for reading can be obtained with
 /// [`Consumer::slots()`].
 ///
 /// When the `Consumer` is dropped, [`Producer::is_abandoned()`] will return `true`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,10 @@
 //! }).join().unwrap();
 //! ```
 //!
-//! For examples that write multiple items at once with [`Producer::write_chunk()`]
-//! and read multiple items with [`Consumer::read_chunk()`]
-//! see the documentation of the [`chunks#examples`] module.
+//! See the documentation of the [`chunks#examples`] module
+//! for examples that write multiple items at once with
+//! [`Producer::write_chunk_uninit()`] and [`Producer::write_chunk()`]
+//! and read multiple items with [`Consumer::read_chunk()`].
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(rust_2018_idioms)]


### PR DESCRIPTION
Closes #56, see the discussion there.

For now, this proposes to add the method `WriteChunkUninit::populate()`, but we might be able to find a better name?

Please note that this method is only available on uninitialized chunks because it would be unnecessary to fill the slots with their `Default` value just to overwrite them again with the values from the iterator.

I still have to clarify this (and probably some other things) in the docs.