### PR TITLE
Add feature "async"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,16 @@ exclude = [
 [features]
 default = ["std"]
 std = []
+async = ["parking_lot"]
 
 [dependencies]
 cache-padded = "1.1"
+parking_lot = {version = "0.11.2", optional = true}
 
 [dev-dependencies]
 rand = "0.7"
 criterion = "0.3"
+tokio = {version = "1.13.0", features = ["rt","macros","time"]}
 
 [lib]
 bench = false # Don't disturb criterion command line parsing

--- a/src/async_rtrb.rs
+++ b/src/async_rtrb.rs
@@ -1,0 +1,419 @@
+use core::{fmt, future::Future, ops::DerefMut, pin::Pin, sync::atomic::Ordering, task::{Context, Poll::{self, Ready}, Waker}};
+
+use parking_lot::Mutex;
+
+use crate::{Consumer, Reactor, Producer, RingBuffer, chunks::{ReadChunk, WriteChunk, WriteChunkUninit}};
+
+impl<T> RingBuffer<T>{
+    /// Creates a `RingBuffer` with the given `capacity` and returns [`Producer`] and [`Consumer`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rtrb::RingBuffer;
+    ///
+    /// let (producer, consumer) = RingBuffer::<f32>::new(100);
+    /// ```
+    ///
+    /// Specifying an explicit type with the [turbofish](https://turbo.fish/)
+    /// is is only necessary if it cannot be deduced by the compiler.
+    ///
+    /// ```
+    /// use rtrb::RingBuffer;
+    ///
+    /// let (mut producer, consumer) = RingBuffer::new_async(100);
+    /// assert_eq!(producer.push(0.0f32), Ok(()));
+    /// ```
+    #[allow(clippy::new_ret_no_self)]
+    #[must_use]
+    pub fn new_async(capacity: usize) -> (Producer<T,ReadWriteReactor>, Consumer<T,ReadWriteReactor>) {
+        RingBuffer::<T,ReadWriteReactor>::with_notifier(capacity)
+    }
+}
+
+/// Trigger futures to wake when new slots are available,or abandoned.
+#[derive(Debug,Default)]
+pub struct ReadWriteReactor{
+    state:Mutex<ReactorState>
+}
+
+#[derive(Debug)]
+pub enum ReactorState{
+    Registered(Waker,usize),
+    Abandoned,
+    Unregistered,
+}
+
+impl Default for ReactorState{
+    fn default() -> Self {
+        ReactorState::Unregistered
+    }
+}
+
+impl ReadWriteReactor{
+    fn pushed_or_popped(&self,n:usize){
+        let mut guard = self.state.lock();
+        let state = guard.deref_mut();
+        if let ReactorState::Registered(_,insufficient_slots) = state{
+            if *insufficient_slots > n{
+                *insufficient_slots -= n;
+            }else{
+                if let ReactorState::Registered(waker,_) = std::mem::take(state){
+                    drop(guard);
+                    waker.wake();
+                }else{
+                    panic!();
+                }
+            }
+        }
+    }
+}
+
+impl Reactor for ReadWriteReactor{
+    fn pushed(&self,n:usize) {
+        self.pushed_or_popped(n);
+    }
+
+    fn popped(&self,n:usize) {
+        self.pushed_or_popped(n);
+    }
+
+    fn abandoned(&self) {
+        let mut guard = self.state.lock();
+        if let ReactorState::Registered(waker,_) = std::mem::replace(&mut *guard,ReactorState::Abandoned){
+            drop(guard);
+            waker.wake();
+        }
+    }
+}
+/// Error type for [`Consumer::read_chunk_async()`], [`Producer::write_chunk_async()`]
+/// and [`Producer::write_chunk_uninit_async()`].
+#[derive(Debug)]
+pub enum AsyncChunkError{
+    /// Available slots are less than desired slots, and it will never increase because it is abandoned.
+    /// Contains the number of slots that were available.
+    TooFewSlotsAndAbandoned(usize),
+    /// Desired slots exceeds capacity.
+    /// Contains the capacity.
+    ExceedCapacity(usize),
+    /// Available slots are less than desired slots,and the other side of ring buffer is also awaiting for new slots.
+    /// First value means the number of new slots the other sides requesting, second value means the number of slots available for you.
+    WillDeadlock(usize,usize),
+}
+
+impl fmt::Display for AsyncChunkError{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        match self{
+            AsyncChunkError::TooFewSlotsAndAbandoned(available_slots) => 
+            alloc::format!("Only {} slots available in ring buffer ,and it will never increase because it was abandoned",available_slots).fmt(f),
+            AsyncChunkError::ExceedCapacity(capacity) => 
+            alloc::format!("Ring buffer has only {} capacity",capacity).fmt(f),
+            AsyncChunkError::WillDeadlock(required, available_slots) => 
+            alloc::format!("Tried to await new slots get available, but the opponent is already awaiting new slots. The opponent  requested {} new slots, you have {} slots available.",required,available_slots).fmt(f),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AsyncChunkError {}
+
+impl<T> Producer<T,ReadWriteReactor>{
+    /// Asynchronously waits `n` slots (initially containing their [`Default`] value) for writing are available and returns it.
+    ///
+    /// [`WriteChunk::as_mut_slices()`] provides mutable access to the slots.
+    /// After writing to those slots, they explicitly have to be made available
+    /// to be read by the [`Consumer`] by calling [`WriteChunk::commit()`]
+    /// or [`WriteChunk::commit_all()`].
+    ///
+    /// For an alternative that does not require the trait bound [`Default`],
+    /// see [`Producer::write_chunk_uninit()`].
+    ///
+    /// If items are supposed to be moved from an iterator into the ring buffer,
+    /// [`Producer::write_chunk_uninit()`] followed by [`WriteChunkUninit::fill_from_iter()`]
+    /// can be used.
+    ///
+    /// # Errors
+    ///
+    /// If not enough slots are available, and awaiting makes nonsense,
+    /// error describing its reason is returned.
+    /// Use [`Producer::slots()`] to obtain the number of available slots beforehand.
+    ///
+    /// # Examples
+    ///
+    /// See the documentation of the [`chunks`](crate::chunks#examples) module.
+    pub async fn write_chunk_async(&mut self, n: usize) -> Result<WriteChunk<'_, T,ReadWriteReactor>, AsyncChunkError>
+    where
+        T: Default,
+    {
+        self.write_chunk_uninit_async(n).await.map(WriteChunk::from)
+    }
+    /// Asynchronously waits `n` (uninitialized) slots for writing are available and returns it.
+    ///
+    /// [`WriteChunkUninit::as_mut_slices()`] provides mutable access
+    /// to the uninitialized slots.
+    /// After writing to those slots, they explicitly have to be made available
+    /// to be read by the [`Consumer`] by calling [`WriteChunkUninit::commit()`]
+    /// or [`WriteChunkUninit::commit_all()`].
+    ///
+    /// Alternatively, [`WriteChunkUninit::fill_from_iter()`] can be used
+    /// to move items from an iterator into the available slots.
+    /// All moved items are automatically made available to be read by the [`Consumer`].
+    ///
+    /// # Errors
+    ///
+    /// If not enough slots are available, and awaiting makes nonsense,
+    /// error describing its reason is returned.
+    /// Use [`Producer::slots()`] to obtain the number of available slots beforehand.
+    ///
+    /// # Safety
+    ///
+    /// This function itself is safe, as is [`WriteChunkUninit::fill_from_iter()`].
+    /// However, when using [`WriteChunkUninit::as_mut_slices()`],
+    /// the user has to make sure that the relevant slots have been initialized
+    /// before calling [`WriteChunkUninit::commit()`] or [`WriteChunkUninit::commit_all()`].
+    ///
+    /// For a safe alternative that provides mutable slices of [`Default`]-initialized slots,
+    /// see [`Producer::write_chunk()`].
+    pub fn write_chunk_uninit_async(&mut self,n:usize) -> impl Future<Output = Result<WriteChunkUninit<'_,T,ReadWriteReactor>,AsyncChunkError>>{ 
+        WriteChunkUninitAsync{
+            producer:Some(self),
+            n:n,
+            waker:None,
+        }
+    }
+}
+
+impl<T> Consumer<T,ReadWriteReactor>{
+    /// Asynchronously waits `n` slots for reading are available and returns it.
+    ///
+    /// [`ReadChunk::as_slices()`] provides immutable access to the slots.
+    /// After reading from those slots, they explicitly have to be made available
+    /// to be written again by the [`Producer`] by calling [`ReadChunk::commit()`]
+    /// or [`ReadChunk::commit_all()`].
+    ///
+    /// Alternatively, items can be moved out of the [`ReadChunk`] using iteration
+    /// because it implements [`IntoIterator`]
+    /// ([`ReadChunk::into_iter()`] can be used to explicitly turn it into an [`Iterator`]).
+    /// All moved items are automatically made available to be written again by the [`Producer`].
+    ///
+    /// # Errors
+    ///
+    /// If not enough slots are available, and awaiting makes nonsense,
+    /// error describing its reason is returned.
+    /// Use [`Consumer::slots()`] to obtain the number of available slots beforehand.
+    ///
+    /// # Examples
+    ///
+    /// See the documentation of the [`chunks`](crate::chunks#examples) module.
+    pub fn read_chunk_async(&mut self, n: usize) -> impl Future<Output = Result<ReadChunk<'_, T,ReadWriteReactor>, AsyncChunkError>> {
+       ReadChunkAsync{
+           consumer:Some(self),
+           n:n,
+           waker:None,
+       }
+    }
+}
+
+impl<T,U:Reactor> Drop for Producer<T,U>{
+    fn drop(&mut self) {
+        self.buffer.reactor.abandoned();
+    }
+}
+impl<T,U:Reactor> Drop for Consumer<T,U>{
+    fn drop(&mut self) {
+        self.buffer.reactor.abandoned();
+    }
+}
+
+struct WriteChunkUninitAsync<'a,T>{
+    producer:Option<&'a mut Producer<T,ReadWriteReactor>>,
+    n:usize,
+    waker:Option<Waker>,
+}
+impl<T> Unpin for WriteChunkUninitAsync<'_,T>{}
+impl<'a,T> Future for WriteChunkUninitAsync<'a,T>{
+    type Output = Result<WriteChunkUninit<'a,T,ReadWriteReactor>,AsyncChunkError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let n = this.n;
+        let producer = this.producer.as_ref().unwrap();
+        let buffer = &producer.buffer;
+        let capacity = buffer.capacity;
+        let tail = producer.tail.get();
+        let waker = &mut this.waker;
+        if waker.is_none(){
+            
+
+            // Check if the queue has *possibly* not enough slots.
+            
+            if capacity - buffer.distance(producer.head.get(), tail) < n {
+                // Refresh the head ...
+                let head = buffer.head.load(Ordering::Acquire);
+                producer.head.set(head);
+
+                // ... and check if there *really* are not enough slots.
+                let slots = capacity - buffer.distance(head, tail);
+                if slots < n {
+                    if capacity < n{
+                        return Ready(Err(AsyncChunkError::ExceedCapacity(capacity)));
+                    }else{
+                        let mut guard = buffer.reactor.state.lock();
+                        // Refresh the head ...
+                        let head = buffer.head.load(Ordering::Acquire);
+                        producer.head.set(head);
+
+                        // ... and check if there *really* are not enough slots.
+                        let slots = capacity - buffer.distance(head, tail);
+                        if slots < n{
+                            let state = guard.deref_mut();
+                            return match *state{
+                                ReactorState::Registered(_, insufficient_slots) => {
+                                    Ready(Err(AsyncChunkError::WillDeadlock(insufficient_slots,slots)))
+                                },
+                                ReactorState::Abandoned => {
+                                    Ready(Err(AsyncChunkError::TooFewSlotsAndAbandoned(slots)))
+                                },
+                                ReactorState::Unregistered => {
+                                    *state = ReactorState::Registered(cx.waker().clone(),n- slots);
+                                    *waker = Some(cx.waker().clone());
+                                    Poll::Pending
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+            
+        }else{
+            this.waker = None;
+            // Refresh the head ...
+            let head = buffer.head.load(Ordering::Acquire);
+            producer.head.set(head);
+
+            // ... and check if there *really* are not enough slots.
+            let slots = capacity - buffer.distance(head, tail);
+            if slots < n{
+                return Ready(Err(AsyncChunkError::TooFewSlotsAndAbandoned(slots)))
+            }
+        }
+        let tail = buffer.collapse_position(tail);
+        let first_len = n.min(capacity - tail);
+        Ready(Ok(WriteChunkUninit {
+            first_ptr: unsafe { buffer.data_ptr.add(tail) },
+            first_len,
+            second_ptr: buffer.data_ptr,
+            second_len: n - first_len,
+            producer: std::mem::take(&mut this.producer).unwrap(),
+        }))
+    }
+}
+impl<T> Drop  for WriteChunkUninitAsync<'_,T>{
+    fn drop(&mut self) {
+        if let Some(waker) = std::mem::take(&mut self.waker){
+            let mut guard = self.producer.as_ref().unwrap().buffer.reactor.state.lock();
+            let state = guard.deref_mut();
+            if let ReactorState::Registered(current_waker,_) = state{
+                if waker.will_wake(current_waker){
+                    *state = ReactorState::Unregistered;
+                }
+            }
+        }
+    }
+}
+
+struct ReadChunkAsync<'a,T>{
+    consumer:Option<&'a mut Consumer<T,ReadWriteReactor>>,
+    n:usize,
+    waker:Option<Waker>,
+}
+impl<T> Unpin for ReadChunkAsync<'_,T>{}
+impl<'a,T> Future for ReadChunkAsync<'a,T>{
+    type Output = Result<ReadChunk<'a,T,ReadWriteReactor>,AsyncChunkError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let n = this.n;
+        let consumer = this.consumer.as_ref().unwrap();
+        let buffer = &consumer.buffer;
+        let capacity = buffer.capacity;
+        let head = consumer.head.get();
+        let waker = &mut this.waker;
+        if waker.is_none(){
+            
+
+            // Check if the queue has *possibly* not enough slots.
+            if buffer.distance(head, consumer.tail.get()) < n {
+                // Refresh the tail ...
+                let tail = buffer.tail.load(Ordering::Acquire);
+                consumer.tail.set(tail);
+
+                // ... and check if there *really* are not enough slots.
+                let slots = buffer.distance(head, tail);
+                if slots < n {
+                    if capacity < n{
+                        return Ready(Err(AsyncChunkError::ExceedCapacity(capacity)));
+                    }else{
+                        let mut guard = buffer.reactor.state.lock();
+                        // Refresh the tail ...
+                        let tail = buffer.tail.load(Ordering::Acquire);
+                        consumer.tail.set(tail);
+
+                        // ... and check if there *really* are not enough slots.
+                        let slots = buffer.distance(head, tail);
+                        if slots < n{
+                            let state = guard.deref_mut();
+                            return match *state{
+                                ReactorState::Registered(_, insufficient_slots) => {
+                                    Ready(Err(AsyncChunkError::WillDeadlock(insufficient_slots,slots)))
+                                },
+                                ReactorState::Abandoned => {
+                                    Ready(Err(AsyncChunkError::TooFewSlotsAndAbandoned(slots)))
+                                },
+                                ReactorState::Unregistered => {
+                                    *state = ReactorState::Registered(cx.waker().clone(),n- slots);
+                                    *waker = Some(cx.waker().clone());
+                                    Poll::Pending
+                                },
+                            }
+                        }
+                    }
+                }
+            }
+            
+        }else{
+            this.waker = None;
+            // Refresh the tail ...
+            let tail = buffer.tail.load(Ordering::Acquire);
+            consumer.tail.set(tail);
+
+            // ... and check if there *really* are not enough slots.
+            let slots = buffer.distance(head, tail);
+            if slots < n{
+                return Ready(Err(AsyncChunkError::TooFewSlotsAndAbandoned(slots)))
+            }
+        }
+        let head = buffer.collapse_position(head);
+        let first_len = n.min(buffer.capacity - head);
+        Ready(Ok(ReadChunk {
+            first_ptr: unsafe { buffer.data_ptr.add(head) },
+            first_len,
+            second_ptr: buffer.data_ptr,
+            second_len: n - first_len,
+            consumer: std::mem::take(&mut this.consumer).unwrap(),
+        }))
+    }
+}
+impl<T> Drop  for ReadChunkAsync<'_,T>{
+    fn drop(&mut self) {
+        if let Some(waker) = std::mem::take(&mut self.waker){
+            let mut guard = self.consumer.as_ref().unwrap().buffer.reactor.state.lock();
+            let state = guard.deref_mut();
+            if let ReactorState::Registered(current_waker,_) = state{
+                if waker.will_wake(current_waker){
+                    *state = ReactorState::Unregistered;
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,13 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use cache_padded::CachePadded;
 
 pub mod chunks;
+mod reactor;
+#[cfg(feature = "async")]
+mod async_rtrb;
+#[cfg(feature = "async")]
+pub use async_rtrb::AsyncChunkError;
 
+use reactor::{DummyReactor, Reactor};
 // This is used in the documentation.
 #[allow(unused_imports)]
 use chunks::WriteChunkUninit;
@@ -73,7 +79,7 @@ use chunks::WriteChunkUninit;
 ///
 /// *See also the [crate-level documentation](crate).*
 #[derive(Debug)]
-pub struct RingBuffer<T> {
+pub struct RingBuffer<T,U:Reactor = DummyReactor> {
     /// The head of the queue.
     ///
     /// This integer is in range `0 .. 2 * capacity`.
@@ -84,6 +90,9 @@ pub struct RingBuffer<T> {
     /// This integer is in range `0 .. 2 * capacity`.
     tail: CachePadded<AtomicUsize>,
 
+    /// Wake up awaiting futures when new slots are available.
+    reactor:CachePadded<U>,
+
     /// The buffer holding slots.
     data_ptr: *mut T,
 
@@ -93,8 +102,7 @@ pub struct RingBuffer<T> {
     /// Indicates that dropping a `RingBuffer<T>` may drop elements of type `T`.
     _marker: PhantomData<T>,
 }
-
-impl<T> RingBuffer<T> {
+impl<T> RingBuffer<T>{
     /// Creates a `RingBuffer` with the given `capacity` and returns [`Producer`] and [`Consumer`].
     ///
     /// # Examples
@@ -117,12 +125,39 @@ impl<T> RingBuffer<T> {
     #[allow(clippy::new_ret_no_self)]
     #[must_use]
     pub fn new(capacity: usize) -> (Producer<T>, Consumer<T>) {
+        Self::with_notifier(capacity)
+    }
+}
+impl<T,U:Reactor> RingBuffer<T,U> {
+    /// Creates a `RingBuffer` with the given `capacity` and returns [`Producer`] and [`Consumer`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rtrb::RingBuffer;
+    ///
+    /// let (producer, consumer) = RingBuffer::<f32>::new(100);
+    /// ```
+    ///
+    /// Specifying an explicit type with the [turbofish](https://turbo.fish/)
+    /// is is only necessary if it cannot be deduced by the compiler.
+    ///
+    /// ```
+    /// use rtrb::RingBuffer;
+    ///
+    /// let (mut producer, consumer) = RingBuffer::new(100);
+    /// assert_eq!(producer.push(0.0f32), Ok(()));
+    /// ```
+    #[allow(clippy::new_ret_no_self)]
+    #[must_use]
+    fn with_notifier(capacity: usize) -> (Producer<T,U>, Consumer<T,U>) {
         let buffer = Arc::new(RingBuffer {
             head: CachePadded::new(AtomicUsize::new(0)),
             tail: CachePadded::new(AtomicUsize::new(0)),
             data_ptr: ManuallyDrop::new(Vec::with_capacity(capacity)).as_mut_ptr(),
             capacity,
             _marker: PhantomData,
+            reactor: Default::default(),
         });
         let p = Producer {
             buffer: buffer.clone(),
@@ -209,7 +244,7 @@ impl<T> RingBuffer<T> {
     }
 }
 
-impl<T> Drop for RingBuffer<T> {
+impl<T,U:Reactor> Drop for RingBuffer<T,U> {
     /// Drops all non-empty slots.
     fn drop(&mut self) {
         let mut head = self.head.load(Ordering::Relaxed);
@@ -230,7 +265,7 @@ impl<T> Drop for RingBuffer<T> {
     }
 }
 
-impl<T> PartialEq for RingBuffer<T> {
+impl<T,U:Reactor> PartialEq for RingBuffer<T,U> {
     /// This method tests for `self` and `other` values to be equal, and is used by `==`.
     ///
     /// # Examples
@@ -250,7 +285,7 @@ impl<T> PartialEq for RingBuffer<T> {
     }
 }
 
-impl<T> Eq for RingBuffer<T> {}
+impl<T,U:Reactor> Eq for RingBuffer<T,U> {}
 
 /// The producer side of a [`RingBuffer`].
 ///
@@ -274,9 +309,9 @@ impl<T> Eq for RingBuffer<T> {}
 /// When the `Producer` is dropped after the [`Consumer`] has already been dropped,
 /// [`RingBuffer::drop()`] will be called, freeing the allocated memory.
 #[derive(Debug, PartialEq, Eq)]
-pub struct Producer<T> {
+pub struct Producer<T,U:Reactor = DummyReactor> {
     /// A reference to the ring buffer.
-    buffer: Arc<RingBuffer<T>>,
+    buffer: Arc<RingBuffer<T,U>>,
 
     /// A copy of `buffer.head` for quick access.
     ///
@@ -289,9 +324,9 @@ pub struct Producer<T> {
     tail: Cell<usize>,
 }
 
-unsafe impl<T: Send> Send for Producer<T> {}
+unsafe impl<T: Send,U:Reactor> Send for Producer<T,U> {}
 
-impl<T> Producer<T> {
+impl<T,U:Reactor> Producer<T,U> {
     /// Attempts to push an element into the queue.
     ///
     /// The element is *moved* into the ring buffer and its slot
@@ -319,6 +354,7 @@ impl<T> Producer<T> {
             let tail = self.buffer.increment1(tail);
             self.buffer.tail.store(tail, Ordering::Release);
             self.tail.set(tail);
+            self.buffer.reactor.pushed1();
             Ok(())
         } else {
             Err(PushError::Full(value))
@@ -432,7 +468,7 @@ impl<T> Producer<T> {
     }
 
     /// Returns a read-only reference to the ring buffer.
-    pub fn buffer(&self) -> &RingBuffer<T> {
+    pub fn buffer(&self) -> &RingBuffer<T,U> {
         &self.buffer
     }
 
@@ -479,9 +515,9 @@ impl<T> Producer<T> {
 /// When the `Consumer` is dropped after the [`Producer`] has already been dropped,
 /// [`RingBuffer::drop()`] will be called, freeing the allocated memory.
 #[derive(Debug, PartialEq, Eq)]
-pub struct Consumer<T> {
+pub struct Consumer<T,U:Reactor = DummyReactor> {
     /// A reference to the ring buffer.
-    buffer: Arc<RingBuffer<T>>,
+    buffer: Arc<RingBuffer<T,U>>,
 
     /// A copy of `buffer.head` for quick access.
     ///
@@ -494,9 +530,9 @@ pub struct Consumer<T> {
     tail: Cell<usize>,
 }
 
-unsafe impl<T: Send> Send for Consumer<T> {}
+unsafe impl<T: Send,U:Reactor> Send for Consumer<T,U> {}
 
-impl<T> Consumer<T> {
+impl<T,U:Reactor> Consumer<T,U> {
     /// Attempts to pop an element from the queue.
     ///
     /// The element is *moved* out of the ring buffer and its slot
@@ -532,6 +568,7 @@ impl<T> Consumer<T> {
             let head = self.buffer.increment1(head);
             self.buffer.head.store(head, Ordering::Release);
             self.head.set(head);
+            self.buffer.reactor.popped1();
             Ok(value)
         } else {
             Err(PopError::Empty)
@@ -670,7 +707,7 @@ impl<T> Consumer<T> {
     }
 
     /// Returns a read-only reference to the ring buffer.
-    pub fn buffer(&self) -> &RingBuffer<T> {
+    pub fn buffer(&self) -> &RingBuffer<T,U> {
         &self.buffer
     }
 

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -1,0 +1,31 @@
+#[cfg(feature = "async")]
+pub use crate::async_rtrb::ReadWriteReactor;
+/// Actually used when async read write operations.
+pub trait Reactor:Default{
+    /// Should call when new read slots are available. Should be called from producer thread.
+    fn pushed(&self,n:usize);
+    /// Should call when new read slots are available. Should be called from producer thread.
+    fn pushed1(&self){
+        self.pushed(1);
+    }
+    /// Should call when new write slots are available. Should be called from consumer thread.
+    fn popped(&self,n:usize);
+    /// Should call when new write slots are available. Should be called from consumer thread.
+    fn popped1(&self){
+        self.popped(1);
+    }
+    /// Should call when consumer or producer has been abandoned.
+    fn abandoned(&self);
+    }
+
+/// Notifier which doesn't do any actual notification.
+#[derive(Debug,Default)]
+pub struct DummyReactor;
+
+impl Reactor for DummyReactor{
+    fn pushed(&self,_n:usize) {}
+
+    fn popped(&self,_n:usize) {}
+
+    fn abandoned(&self) {}
+}

--- a/tests/async_operations.rs
+++ b/tests/async_operations.rs
@@ -1,0 +1,57 @@
+#![cfg(feature = "async")]
+use rtrb::RingBuffer;
+use rtrb::*;
+
+#[tokio::test]
+async fn exceed_capacity(){
+    let (mut p, mut c) = RingBuffer::<i32>::new_async(1);
+    assert!(matches!(p.write_chunk_async(2).await.unwrap_err(),AsyncChunkError::ExceedCapacity(1))); 
+    assert!(matches!(c.read_chunk_async(2).await.unwrap_err(),AsyncChunkError::ExceedCapacity(1)));
+}
+
+#[tokio::test]
+async fn read_async(){
+    let (mut p, mut c) = RingBuffer::new_async(1);
+    let value = 2021;
+    let consume = tokio::spawn(async move{
+        let chunk = c.read_chunk_async(1).await.unwrap();
+        chunk.into_iter().next().unwrap()
+    });
+    p.push(value).unwrap();
+    assert_eq!(consume.await.unwrap(),value);
+    
+}
+#[tokio::test]
+async fn write_async(){
+    let (mut p, mut c) = RingBuffer::new_async(1);
+    p.push(0).unwrap();
+    let value = 2021;
+    let produce = tokio::spawn(async move{
+        let chunk = p.write_chunk_uninit_async(1).await.unwrap();
+        chunk.fill_from_iter(core::iter::once(value));
+    });
+
+    assert_eq!(c.pop().unwrap(),0);
+    produce.await.unwrap();
+    assert_eq!(c.pop().unwrap(),value);
+    
+}
+#[tokio::test]
+async fn abandon(){
+    let (p, mut c) = RingBuffer::<i32>::new_async(1);
+    tokio::join!(async move{
+        assert!(matches!(c.read_chunk_async(1).await.unwrap_err(),AsyncChunkError::TooFewSlotsAndAbandoned(0)));
+        assert!(matches!(c.read_chunk_async(1).await.unwrap_err(),AsyncChunkError::TooFewSlotsAndAbandoned(0)));
+    },async move{drop(p)});
+}
+#[tokio::test]
+async fn deadlock(){
+    let (mut p, mut c) = RingBuffer::<i32>::new_async(2);
+    p.push(1).unwrap();
+    tokio::join!(async move{
+        c.read_chunk_async(2).await.unwrap();
+    },async move{
+        assert!(matches!(p.write_chunk_uninit_async(2).await.unwrap_err(),AsyncChunkError::WillDeadlock(1,1)));
+        p.push(2).unwrap();
+    });
+}


### PR DESCRIPTION
Use `RingBuffer::<T>::new_async(usize)` to create ring buffer with async read write support.
Use `write_chunk_uninit_async`, `write_chunk_async`, `read_chunk_async` to asynchronously wait for requested number of slots gets available.