### PR TITLE
Fix some leaks and add more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ Creating the HTML docs (which will be available in `target/doc/rtrb/index.html`)
 
     cargo doc
 
+To measure code coverage, nightly Rust is required, as well as a few additional dependencies:
+
+    rustup toolchain install nightly
+    rustup component add llvm-tools-preview
+    cargo install grcov
+
+Test coverage data can be obtained and analyzed with these commands:
+
+    cargo clean
+    RUSTFLAGS="-Z instrument-coverage" RUSTDOCFLAGS="-Z instrument-coverage -Z unstable-options --persist-doctests target/debug/doctestbins" LLVM_PROFILE_FILE="coverage/%p-%m.profraw" cargo +nightly test
+    grcov coverage --source-dir . --binary-path target/debug --output-type html --output-path coverage
+
+The last command creates an HTML report in `coverage/index.html`.
+
 
 Minimum Supported `rustc` Version
 ---------------------------------

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -819,6 +819,7 @@ impl std::io::Write for Producer<u8> {
         Ok(end)
     }
 
+    #[inline]
     fn flush(&mut self) -> std::io::Result<()> {
         // Nothing to do here.
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,8 +245,7 @@ impl<T> PartialEq for RingBuffer<T> {
     /// assert_ne!(p1.buffer(), p2.buffer());
     /// ```
     fn eq(&self, other: &Self) -> bool {
-        // There can never be multiple instances with the same `data_ptr`.
-        core::ptr::eq(self.data_ptr, other.data_ptr)
+        core::ptr::eq(self, other)
     }
 }
 

--- a/tests/chunks.rs
+++ b/tests/chunks.rs
@@ -25,3 +25,53 @@ fn zero_capacity() {
         unreachable!();
     }
 }
+
+#[test]
+fn drop_write_chunk() {
+    // Static variable to count all drop() invocations
+    static mut DROP_COUNT: i32 = 0;
+
+    #[derive(Default)]
+    struct Thing;
+
+    impl Drop for Thing {
+        fn drop(&mut self) {
+            unsafe {
+                DROP_COUNT += 1;
+            }
+        }
+    }
+
+    {
+        let (mut p, mut c) = RingBuffer::new(3);
+
+        if let Ok(mut chunk) = p.write_chunk(3) {
+            let (first, _second) = chunk.as_mut_slices();
+            assert_eq!(unsafe { DROP_COUNT }, 0);
+            first[0] = Thing;
+            // Overwriting drops the original Default element:
+            assert_eq!(unsafe { DROP_COUNT }, 1);
+            chunk.commit(1);
+            // After committing, 2 (unwritten) slots are dropped
+            assert_eq!(unsafe { DROP_COUNT }, 3);
+        } else {
+            unreachable!();
+        }
+
+        let chunk = c.read_chunk(1).unwrap();
+        // Drop count is unchanged:
+        assert_eq!(unsafe { DROP_COUNT }, 3);
+        chunk.commit_all();
+        // The stored element is never read, but it is dropped:
+        assert_eq!(unsafe { DROP_COUNT }, 4);
+
+        let chunk = p.write_chunk(3).unwrap();
+        // Drop count is unchanged:
+        assert_eq!(unsafe { DROP_COUNT }, 4);
+        drop(chunk);
+        // All three slots of the chunk are dropped:
+        assert_eq!(unsafe { DROP_COUNT }, 7);
+    }
+    // RingBuffer was already empty, nothing is dropped:
+    assert_eq!(unsafe { DROP_COUNT }, 7);
+}

--- a/tests/chunks.rs
+++ b/tests/chunks.rs
@@ -1,0 +1,27 @@
+use rtrb::{chunks::ChunkError, RingBuffer};
+
+#[test]
+fn zero_capacity() {
+    let (mut p, mut c) = RingBuffer::<i32>::new(0);
+
+    assert_eq!(p.write_chunk(1).unwrap_err(), ChunkError::TooFewSlots(0));
+    assert_eq!(c.read_chunk(1).unwrap_err(), ChunkError::TooFewSlots(0));
+
+    if let Ok(mut chunk) = p.write_chunk(0) {
+        let (first, second) = chunk.as_mut_slices();
+        assert!(first.is_empty());
+        assert!(second.is_empty());
+        chunk.commit_all();
+    } else {
+        unreachable!();
+    }
+
+    if let Ok(chunk) = c.read_chunk(0) {
+        let (first, second) = chunk.as_slices();
+        assert!(first.is_empty());
+        assert!(second.is_empty());
+        chunk.commit_all();
+    } else {
+        unreachable!();
+    }
+}

--- a/tests/chunks.rs
+++ b/tests/chunks.rs
@@ -46,6 +46,8 @@ fn zero_capacity() {
     assert_eq!(c.read_chunk(1).unwrap_err(), ChunkError::TooFewSlots(0));
 
     if let Ok(mut chunk) = p.write_chunk(0) {
+        assert_eq!(chunk.len(), 0);
+        assert!(chunk.is_empty());
         let (first, second) = chunk.as_mut_slices();
         assert!(first.is_empty());
         assert!(second.is_empty());
@@ -55,6 +57,8 @@ fn zero_capacity() {
     }
 
     if let Ok(chunk) = c.read_chunk(0) {
+        assert_eq!(chunk.len(), 0);
+        assert!(chunk.is_empty());
         let (first, second) = chunk.as_slices();
         assert!(first.is_empty());
         assert!(second.is_empty());

--- a/tests/chunks.rs
+++ b/tests/chunks.rs
@@ -117,3 +117,29 @@ fn drop_write_chunk() {
     // RingBuffer was already empty, nothing is dropped:
     assert_eq!(unsafe { DROP_COUNT }, 7);
 }
+
+#[test]
+fn trait_impls() {
+    let (mut p, mut c) = RingBuffer::<u8>::new(0);
+
+    if let Ok(chunk) = p.write_chunk(0) {
+        assert!(format!("{:?}", chunk).starts_with("WriteChunk"));
+    } else {
+        unreachable!();
+    }
+    if let Ok(chunk) = p.write_chunk_uninit(0) {
+        assert!(format!("{:?}", chunk).starts_with("WriteChunkUninit"));
+    } else {
+        unreachable!();
+    }
+    if let Ok(chunk) = c.read_chunk(0) {
+        assert!(format!("{:?}", chunk).starts_with("ReadChunk"));
+        let iter = chunk.into_iter();
+        assert!(format!("{:?}", iter).starts_with("ReadChunkIntoIter"));
+    } else {
+        unreachable!();
+    }
+    let e = c.read_chunk(100).unwrap_err();
+    assert_eq!(format!("{:?}", e), "TooFewSlots(0)");
+    assert_eq!(e.to_string(), "only 0 slots available in ring buffer");
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -118,3 +118,23 @@ fn drops() {
         assert_eq!(DROPS.load(Ordering::SeqCst), steps + additional);
     }
 }
+
+#[test]
+fn trait_impls() {
+    let (mut p, mut c) = RingBuffer::<u8>::new(0);
+
+    assert!(format!("{:?}", p.buffer()).starts_with("RingBuffer {"));
+    assert!(format!("{:?}", p).starts_with("Producer {"));
+    assert!(format!("{:?}", c).starts_with("Consumer {"));
+
+    assert_eq!(format!("{:?}", p.push(42).unwrap_err()), "Full(_)");
+    assert_eq!(p.push(42).unwrap_err().to_string(), "full ring buffer");
+    assert_eq!(format!("{:?}", c.pop().unwrap_err()), "Empty");
+    assert_eq!(c.pop().unwrap_err().to_string(), "empty ring buffer");
+    assert_eq!(format!("{:?}", c.peek().unwrap_err()), "Empty");
+    assert_eq!(c.peek().unwrap_err().to_string(), "empty ring buffer");
+
+    let (another_p, another_c) = RingBuffer::<u8>::new(0);
+    assert_ne!(p, another_p);
+    assert_ne!(c, another_c);
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,20 +5,8 @@ use rand::{thread_rng, Rng};
 use rtrb::RingBuffer;
 
 #[test]
-fn smoke() {
-    let (mut p, mut c) = RingBuffer::new(1);
-
-    p.push(7).unwrap();
-    assert_eq!(c.pop(), Ok(7));
-
-    p.push(8).unwrap();
-    assert_eq!(c.pop(), Ok(8));
-    assert!(c.pop().is_err());
-}
-
-#[test]
 fn capacity() {
-    for i in 1..10 {
+    for i in 0..10 {
         let (p, c) = RingBuffer::<i32>::new(i);
         assert_eq!(p.buffer().capacity(), i);
         assert_eq!(c.buffer().capacity(), i);

--- a/tests/push_and_pop.rs
+++ b/tests/push_and_pop.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rand::{thread_rng, Rng};
 
-use rtrb::{chunks::ChunkError, RingBuffer};
+use rtrb::RingBuffer;
 
 #[test]
 fn smoke() {
@@ -37,27 +37,6 @@ fn zero_capacity() {
 
     assert!(p.push(10).is_err());
     assert!(c.pop().is_err());
-
-    assert_eq!(p.write_chunk(1).unwrap_err(), ChunkError::TooFewSlots(0));
-    assert_eq!(c.read_chunk(1).unwrap_err(), ChunkError::TooFewSlots(0));
-
-    if let Ok(mut chunk) = p.write_chunk(0) {
-        let (first, second) = chunk.as_mut_slices();
-        assert!(first.is_empty());
-        assert!(second.is_empty());
-        chunk.commit_all();
-    } else {
-        unreachable!();
-    }
-
-    if let Ok(chunk) = c.read_chunk(0) {
-        let (first, second) = chunk.as_slices();
-        assert!(first.is_empty());
-        assert!(second.is_empty());
-        chunk.commit_all();
-    } else {
-        unreachable!();
-    }
 }
 
 #[test]

--- a/tests/write_and_read.rs
+++ b/tests/write_and_read.rs
@@ -8,6 +8,8 @@ use rtrb::RingBuffer;
 fn write_and_read() {
     let (mut p, mut c) = RingBuffer::new(2);
     assert_eq!(p.write(&[10, 11]).unwrap(), 2);
+    // Does nothing:
+    assert!(p.flush().is_ok());
 
     {
         let mut buf = [0];


### PR DESCRIPTION
When I removed the `Copy` trait bound from `WriteChunk` (https://github.com/mgeier/rtrb/pull/57/commits/148cf65656bd51f8a7045aa439ddbf8e62378546), I inadvertently created a few potential leaks.

I guess leaking `Default`-initialized values isn't a big deal in most cases, but it should be fixed nevertheless. Which this PR hopefully achieves (see 4905881f53fdd68c312fe2eafd2aa03c38a11be3).

I also added a few more tests to increase test coverage and I added instructions how to measure coverage.