### PR TITLE
WriteChunk: use PhantomData<T>

### DIFF
--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -169,6 +169,7 @@
 //! ```
 
 use core::fmt;
+use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::sync::atomic::Ordering;
 
@@ -321,7 +322,7 @@ impl<T> Consumer<T> {
 /// which also allows moving items from an iterator into the ring buffer
 /// by means of [`WriteChunkUninit::fill_from_iter()`].
 #[derive(Debug, PartialEq, Eq)]
-pub struct WriteChunk<'a, T>(Option<WriteChunkUninit<'a, T>>);
+pub struct WriteChunk<'a, T>(Option<WriteChunkUninit<'a, T>>, PhantomData<T>);
 
 impl<T> Drop for WriteChunk<'_, T> {
     fn drop(&mut self) {
@@ -352,7 +353,7 @@ where
                 chunk.second_ptr.add(i).write(Default::default());
             }
         }
-        WriteChunk(Some(chunk))
+        WriteChunk(Some(chunk), PhantomData)
     }
 }
 


### PR DESCRIPTION
I'm not sure, but I think this might be necessary for drop check, because dropping `WriteChunk` might drop elements of `T` (if they haven't been committed).

I've found this while working on #75, but that might be merged late or never, so I'm proposing to merge it separately.