### PR TITLE
Limit cache-padded to 1.2.*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-cache-padded = "1.1"
+cache-padded = "1.2.*"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
Version 1.3 is marked as deprecated, which causes a warning.

I would like to wait with the change to crossbeam-utils, because currently it doesn't support our MSRV.