### PR TITLE
Draft: Add force_push(..) to Producer

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -154,3 +154,21 @@ fn no_race_with_is_abandoned() {
     }
     t.join().unwrap();
 }
+
+#[test]
+fn simple_force_push() {
+    let (mut p, mut c) = RingBuffer::<u8>::new(1);
+    p.force_push(1);
+    p.force_push(2);
+    p.force_push(3);
+    assert_eq!(c.pop(), Ok(3));
+}
+
+#[test]
+fn force_push() {
+    let (mut p, mut c) = RingBuffer::<u8>::new(2);
+    p.force_push(1);
+    p.force_push(2);
+    p.force_push(3);
+    assert_eq!(c.pop(), Ok(3));
+}


### PR DESCRIPTION
I started investigating if it's possible to implement a force push method. I would like to have this, as I want to synchronize state between a DSP realtime thread and the ui. I simply want to have the latest state in the ui, ignoring if the ui read the previous pushed states or not. The queue will be of size 2, if possible even 1.

What I'm currently unsure with, is if It's possible with this patch, that the producer is writing in the same field as the consumer is currently reading from? And how could I prevent this from happening? Maybe force_next_tail() would need to be smarter?