### PR TITLE
Use CachePadded from crossbeam submodule

### DIFF
--- a/.github/workflows/cache-padded-updates.yml
+++ b/.github/workflows/cache-padded-updates.yml
@@ -1,0 +1,20 @@
+name: Check for changes in cache_padded.rs
+on:
+  schedule:
+    - cron: "11 11 * * Mon"
+jobs:
+  check-cache-padded:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Git repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Fetch newest stuff from crossbeam submodule
+        working-directory: crossbeam
+        run: |
+          git fetch origin master
+      - name: Check for changes in cache_padded.rs
+        working-directory: crossbeam
+        run: |
+          git diff origin/master -- crossbeam-utils/src/cache_padded.rs

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "crossbeam"]
+	path = crossbeam
+	url = https://github.com/crossbeam-rs/crossbeam.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,11 @@ exclude = [
 default = ["std"]
 std = []
 
-[dependencies]
-# "std" is enabled by default
-crossbeam-utils = { version = "0.8", default-features = false }
-
 [dev-dependencies]
 rand = "0.8"
 criterion = "0.3"
+# TODO: This is only needed for the doctests of cache_padded.rs! Is there a way to avoid this?
+crossbeam-utils = { version = "0.8", default-features = false }
 
 [profile.bench]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ Licensed under either of
 
 at your option.
 
+Note that this crate contains a copy of the file `cache_padded.rs` from
+https://github.com/crossbeam-rs/crossbeam.
+
 #### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted

--- a/src/cache_padded.rs
+++ b/src/cache_padded.rs
@@ -1,0 +1,1 @@
+../crossbeam/crossbeam-utils/src/cache_padded.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,9 @@ use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use crossbeam_utils::CachePadded;
+#[allow(dead_code)]
+mod cache_padded;
+use cache_padded::CachePadded;
 
 pub mod chunks;
 


### PR DESCRIPTION
Getting the latest version of `crossbeam-utils` requires an MSRV bump which would otherwise not be necessary.

See also: https://github.com/crossbeam-rs/crossbeam/issues/1066

I have tried to solve this within `crossbeam-utils` (https://github.com/crossbeam-rs/crossbeam/pull/1075), but if that doesn't work out, here's an alternative hack to avoid the MSRV bump.