### PR TITLE
Embrace unsafe_op_in_unsafe_fn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-#[allow(dead_code)]
+#[allow(dead_code, clippy::undocumented_unsafe_blocks)]
 mod cache_padded;
 use cache_padded::CachePadded;
 


### PR DESCRIPTION
This will become a warning in the 2024 edition of Rust, so we might as well get used to it ...