### PR TITLE
Update is_abandoned() test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,5 +139,8 @@ jobs:
       - name: Run ThreadSanitizer
         env:
           RUSTFLAGS: "-Z sanitizer=thread"
+        # "no_race_with_is_abandoned" is skipped because ThreadSanitizer
+        # reports false positives when using standalone fences,
+        # see https://github.com/google/sanitizers/issues/1415.
         run: |
-          cargo test --tests -Z build-std --target x86_64-unknown-linux-gnu
+          cargo test --tests -Z build-std --target x86_64-unknown-linux-gnu -- --skip no_race_with_is_abandoned

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,6 +117,12 @@ jobs:
       - name: Run Miri
         run: |
           cargo miri test
+      - name: Run Miri again (with miri-preemption-rate=0)
+        env:
+          MIRIFLAGS: "-Zmiri-preemption-rate=0" 
+        # For now, this is only run on one test, see https://github.com/mgeier/rtrb/issues/114
+        run: |
+          cargo miri test no_race_with_is_abandoned
 
   thread-sanitizer:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Testing with Miri also needs nightly Rust:
 
     cargo +nightly miri test
 
+This Miri flag should also be tried:
+
+    MIRIFLAGS="-Zmiri-preemption-rate=0" cargo +nightly miri test
+
 Running the tests with ThreadSanitizer requires nightly Rust as well:
 
     RUSTFLAGS="-Z sanitizer=thread" cargo +nightly test --tests -Z build-std --target x86_64-unknown-linux-gnu

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -146,11 +146,9 @@ fn no_race_with_is_abandoned() {
         unsafe { V = 10 };
         drop(p);
     });
+    std::thread::yield_now();
     if c.is_abandoned() {
         unsafe { V = 20 };
-    } else {
-        // This is not synchronized, both Miri and ThreadSanitizer should detect a data race:
-        //unsafe { V = 30 };
     }
     t.join().unwrap();
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -151,6 +151,7 @@ fn no_race_with_is_abandoned() {
         });
         std::thread::yield_now();
         if c.is_abandoned() {
+            std::sync::atomic::fence(std::sync::atomic::Ordering::Acquire);
             unsafe { V = 20 };
         }
         t.join().unwrap();


### PR DESCRIPTION
This reproduces the problem described in #114 with Miri and fixes the test (but not the underlying problem) by using a fence.

Using a fence might give false positives with ThreadSanitizer, see https://github.com/google/sanitizers/issues/1415, therefore it is deactivated for this test.