### PR TITLE
performance comparison: remove "magnetic"

### DIFF
--- a/performance-comparison/Cargo.toml
+++ b/performance-comparison/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 concurrent-queue = "2.3"
 crossbeam-queue = "0.3"
 crossbeam-queue-pr338 = { git = "https://github.com/mgeier/crossbeam", branch = "spsc", package = "crossbeam-queue" }
-magnetic = "2"
 npnc = "0.2"
 omango = "0.2"
 ringbuf = "0.4"

--- a/performance-comparison/benches/two_threads.rs
+++ b/performance-comparison/benches/two_threads.rs
@@ -2,9 +2,6 @@
 #[macro_use]
 mod two_threads;
 
-use magnetic::Consumer as _;
-use magnetic::Producer as _;
-
 use ringbuf::traits::Consumer as _;
 use ringbuf::traits::Producer as _;
 use ringbuf::traits::Split as _;
@@ -36,15 +33,7 @@ create_two_threads_benchmark!(
     |p, i| p.try_push(i).is_ok(),
     |c| c.try_pop();
 
-    "6-magnetic",
-    |capacity| {
-        let buffer = magnetic::buffer::dynamic::DynamicBuffer::new(capacity).unwrap();
-        magnetic::spsc::spsc_queue(buffer)
-    },
-    |p, i| p.try_push(i).is_ok(),
-    |c| c.try_pop().ok();
-
-    "7-concurrent-queue",
+    "6-concurrent-queue",
     |capacity| {
         let q = std::sync::Arc::new(concurrent_queue::ConcurrentQueue::bounded(capacity));
         (q.clone(), q)
@@ -52,7 +41,7 @@ create_two_threads_benchmark!(
     |q, i| q.push(i).is_ok(),
     |q| q.pop().ok();
 
-    "8-crossbeam-queue",
+    "7-crossbeam-queue",
     |capacity| {
         let q = std::sync::Arc::new(crossbeam_queue::ArrayQueue::new(capacity));
         (q.clone(), q)


### PR DESCRIPTION
This seems to behave very poorly in the uncontended benchmark on an AMD CPU, see https://github.com/mgeier/rtrb/issues/39#issuecomment-2132797629.

Apart from this, it doesn't seem to be actively maintained nor heavily used.

https://crates.io/crates/magnetic
https://github.com/johnshaw/magnetic