### PR TITLE
Cache both head and tail index in both Consumer and Producer (again)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,8 @@ pub struct Producer<T> {
     /// A copy of `buffer.tail` for quick access.
     ///
     /// This value is always in sync with `buffer.tail`.
+    // NB: Caching the tail seems to have little effect on Intel CPUs, but it seems to
+    //     improve performance on AMD CPUs, see https://github.com/mgeier/rtrb/pull/132
     cached_tail: Cell<usize>,
 }
 
@@ -496,6 +498,8 @@ pub struct Consumer<T> {
     /// A copy of `buffer.head` for quick access.
     ///
     /// This value is always in sync with `buffer.head`.
+    // NB: Caching the head seems to have little effect on Intel CPUs, but it seems to
+    //     improve performance on AMD CPUs, see https://github.com/mgeier/rtrb/pull/132
     cached_head: Cell<usize>,
 
     /// A copy of `buffer.tail` for quick access.


### PR DESCRIPTION
This reverts PR #48.

This may or may not be faster on AMD CPUs.

Performance comparisons in https://github.com/mgeier/rtrb/issues/39#issuecomment-2132797629 and https://github.com/mgeier/rtrb/issues/39#issuecomment-2563504188 show that `rtrb` is significantly slower (in the contended case) than the crossbeam PR it is based on (https://github.com/crossbeam-rs/crossbeam/pull/338).

There shouldn't be too many differences between the two code bases, but one of them is #48, so maybe that's the cause for the regression?

It might also be unrelated, though. This PR should only be merged if it shows a clear improvement on AMD CPUs. Ideally, it should have the same performance as (or even better than) crossbeam PR 338.

If this PR doesn't show any improvements on AMD, we'll have to keep looking ...