### PR TITLE
Change syntax of benchmark macro invocation

### DIFF
--- a/benches/two_threads.rs
+++ b/benches/two_threads.rs
@@ -1,5 +1,5 @@
 macro_rules! create_two_threads_benchmark {
-    ($($id:literal, $create:expr, $push:expr, $pop:expr,)::+) => {
+    ($($id:literal, $create:expr, $push:expr, $pop:expr,::)+) => {
 
 use std::convert::TryInto as _;
 use std::sync::{Arc, Barrier};
@@ -170,4 +170,5 @@ create_two_threads_benchmark!(
     rtrb::RingBuffer::new,
     |p, i| p.push(i).is_ok(),
     |c| c.pop().ok(),
+    ::
 );

--- a/benches/two_threads.rs
+++ b/benches/two_threads.rs
@@ -1,5 +1,5 @@
 macro_rules! create_two_threads_benchmark {
-    ($($id:literal, $create:expr, $push:expr, $pop:expr);+) => {
+    ($($id:literal, $create:expr, $push:expr, $pop:expr,)::+) => {
 
 use std::convert::TryInto as _;
 use std::sync::{Arc, Barrier};
@@ -169,5 +169,5 @@ create_two_threads_benchmark!(
     "rtrb",
     rtrb::RingBuffer::new,
     |p, i| p.push(i).is_ok(),
-    |c| c.pop().ok()
+    |c| c.pop().ok(),
 );

--- a/performance-comparison/benches/two_threads.rs
+++ b/performance-comparison/benches/two_threads.rs
@@ -7,46 +7,44 @@ use ringbuf::traits::Producer as _;
 use ringbuf::traits::Split as _;
 
 create_two_threads_benchmark!(
-
     "1-npnc",
     |capacity| npnc::bounded::spsc::channel(capacity.next_power_of_two()),
     |p, i| p.produce(i).is_ok(),
-    |c| c.consume().ok();
-
+    |c| c.consume().ok(),
+    ::
     "2-crossbeam-queue-pr338",
     crossbeam_queue_pr338::spsc::new,
     |q, i| q.push(i).is_ok(),
-    |q| q.pop().ok();
-
+    |q| q.pop().ok(),
+    ::
     "3-rtrb",
     rtrb::RingBuffer::new,
     |p, i| p.push(i).is_ok(),
-    |c| c.pop().ok();
-
+    |c| c.pop().ok(),
+    ::
     "4-omango",
     |capacity| omango::queue::spsc::bounded(u32::try_from(capacity).unwrap()),
     |p, i| p.try_send(i).is_ok(),
-    |c| c.try_recv().ok();
-
+    |c| c.try_recv().ok(),
+    ::
     "5-ringbuf",
     |capacity| ringbuf::HeapRb::new(capacity).split(),
     |p, i| p.try_push(i).is_ok(),
-    |c| c.try_pop();
-
+    |c| c.try_pop(),
+    ::
     "6-concurrent-queue",
     |capacity| {
         let q = std::sync::Arc::new(concurrent_queue::ConcurrentQueue::bounded(capacity));
         (q.clone(), q)
     },
     |q, i| q.push(i).is_ok(),
-    |q| q.pop().ok();
-
+    |q| q.pop().ok(),
+    ::
     "7-crossbeam-queue",
     |capacity| {
         let q = std::sync::Arc::new(crossbeam_queue::ArrayQueue::new(capacity));
         (q.clone(), q)
     },
     |q, i| q.push(i).is_ok(),
-    |q| q.pop()
-
+    |q| q.pop(),
 );

--- a/performance-comparison/benches/two_threads.rs
+++ b/performance-comparison/benches/two_threads.rs
@@ -47,4 +47,5 @@ create_two_threads_benchmark!(
     },
     |q, i| q.push(i).is_ok(),
     |q| q.pop(),
+    ::
 );


### PR DESCRIPTION
Ending every line (including the last one) with a comma looks more consistent.

`::` seems to be a nice separator.