### PR TITLE
performance-comparison: replace npnc by bounded-spsc-queue

### DIFF
--- a/benches/two_threads.rs
+++ b/benches/two_threads.rs
@@ -30,7 +30,7 @@ $(
     assert!(pop(&mut c).is_none());
 )+
 
-    let mut group_large = criterion.benchmark_group("two-threads-large");
+    let mut group_large = criterion.benchmark_group("large");
     group_large.throughput(criterion::Throughput::Bytes(1));
 $(
     group_large.bench_function($id, |b| {
@@ -117,7 +117,7 @@ $(
 )+
     group_large.finish();
 
-    let mut group_small = criterion.benchmark_group("two-threads-small");
+    let mut group_small = criterion.benchmark_group("small");
     group_small.throughput(criterion::Throughput::Bytes(1));
 $(
     group_small.bench_function($id, |b| {

--- a/performance-comparison/Cargo.toml
+++ b/performance-comparison/Cargo.toml
@@ -6,10 +6,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
+# We use a fork that doesn't select the since stabilized `allocator_api` feature,
+# see https://github.com/polyfractal/bounded-spsc-queue/pull/22:
+bounded-spsc-queue = { git = "https://github.com/knsd/bounded-spsc-queue.git", branch = "feature/stable" }
 concurrent-queue = "2.3"
 crossbeam-queue = "0.3"
 crossbeam-queue-pr338 = { git = "https://github.com/mgeier/crossbeam", branch = "spsc", package = "crossbeam-queue" }
-npnc = "0.2"
 omango = "0.2"
 ringbuf = "0.4"
 rtrb = { path = ".." }

--- a/performance-comparison/benches/two_threads.rs
+++ b/performance-comparison/benches/two_threads.rs
@@ -7,10 +7,10 @@ use ringbuf::traits::Producer as _;
 use ringbuf::traits::Split as _;
 
 create_two_threads_benchmark!(
-    "1-npnc",
-    |capacity| npnc::bounded::spsc::channel(capacity.next_power_of_two()),
-    |p, i| p.produce(i).is_ok(),
-    |c| c.consume().ok(),
+    "1-bounded-spsc-queue", // calls next_power_of_two()
+    bounded_spsc_queue::make,
+    |p, i| p.try_push(i).is_none(),
+    |c| c.try_pop(),
     ::
     "2-crossbeam-queue-pr338",
     crossbeam_queue_pr338::spsc::new,


### PR DESCRIPTION
Both project seem to be abandoned, both use power-of-2 buffer sizes, but `bounded-spsc-queue` performs much better in the "small" case.