### PR TITLE
performance-comparison: remove concurrent-queue

### DIFF
--- a/performance-comparison/benches/two_threads.rs
+++ b/performance-comparison/benches/two_threads.rs
@@ -32,15 +32,7 @@ create_two_threads_benchmark!(
     |p, i| p.try_push(i).is_ok(),
     |c| c.try_pop(),
     ::
-    "6-concurrent-queue",
-    |capacity| {
-        let q = std::sync::Arc::new(concurrent_queue::ConcurrentQueue::bounded(capacity));
-        (q.clone(), q)
-    },
-    |q, i| q.push(i).is_ok(),
-    |q| q.pop().ok(),
-    ::
-    "7-crossbeam-queue",
+    "6-crossbeam-queue",
     |capacity| {
         let q = std::sync::Arc::new(crossbeam_queue::ArrayQueue::new(capacity));
         (q.clone(), q)


### PR DESCRIPTION
This isn't about comparing different MPMC queues, so I think one of them has to be enough to have as a "worst case" anchor.

If somebody is interested in that comparison, they can easily add it back.