### PR TITLE
Use `must_use` in *_partial_slice()

### DIFF
--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -277,6 +277,7 @@ impl<T: Copy> Producer<T> {
     /// ```
     ///
     /// For more examples, see the documentation of the [`chunks`](crate::chunks#examples) module.
+    #[must_use]
     pub fn push_partial_slice<'a>(&mut self, slice: &'a [T]) -> (&'a [T], &'a [T]) {
         let slots = if self.cached_slots() < slice.len() {
             slice.len().min(self.slots())
@@ -403,6 +404,7 @@ impl<T: Copy> Consumer<T> {
     /// ```
     ///
     /// For more examples, see the documentation of the [`chunks`](crate::chunks#examples) module.
+    #[must_use]
     pub fn pop_partial_slice<'a>(&mut self, slice: &'a mut [T]) -> (&'a mut [T], &'a mut [T]) {
         // SAFETY: Transmuting &mut [T] to &mut [MaybeUninit<T>] is generally unsafe!
         // However, since we can guarantee that only valid T values will ever be written,
@@ -486,6 +488,7 @@ impl<T: Copy> Consumer<T> {
     /// assert_eq!(buffer, [-42, 2, 3, 99]);
     /// ```
     #[inline]
+    #[must_use]
     pub fn pop_partial_slice_uninit<'a>(
         &mut self,
         slice: &'a mut [MaybeUninit<T>],

--- a/tests/chunks.rs
+++ b/tests/chunks.rs
@@ -194,7 +194,8 @@ fn push_pop_partial_slice() {
     let (popped, unused) = c.pop_partial_slice(&mut buf);
     assert_eq!(popped, &[1, 2, 3, 4, 5]);
     assert_eq!(unused.len(), buf_len - popped.len());
-    p.push_partial_slice(popped);
+    let (pushed, _) = p.push_partial_slice(popped);
+    assert_eq!(pushed.len(), 5);
 
     let (pushed, rest) = p.push_partial_slice(&[1, 2, 3, 4, 5]);
     assert_eq!(pushed, &[1, 2, 3]);


### PR DESCRIPTION
The `*_entire_slice()` functions return `Result`, which already causes a warning if ignored, this PR adds a warning for the `*_partial_slice()` functions as well.

@JalonWong Could you please review, since this touches the code you have written?