### PR TITLE
Avoid allocation in Display for ChunkError

### DIFF
--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -1188,9 +1188,7 @@ impl std::error::Error for ChunkError {}
 impl fmt::Display for ChunkError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ChunkError::TooFewSlots(n) => {
-                alloc::format!("only {} slots available in ring buffer", n).fmt(f)
-            }
+            ChunkError::TooFewSlots(_) => "too few slots available in ring buffer".fmt(f),
         }
     }
 }

--- a/tests/chunks.rs
+++ b/tests/chunks.rs
@@ -200,7 +200,7 @@ fn trait_impls() {
     }
     let e = c.read_chunk(100).unwrap_err();
     assert_eq!(format!("{:?}", e), "TooFewSlots(0)");
-    assert_eq!(e.to_string(), "only 0 slots available in ring buffer");
+    assert_eq!(e.to_string(), "too few slots available in ring buffer");
 }
 
 #[test]


### PR DESCRIPTION
We don't need to show the number here, because this is probably never used anyway. The Debug impl still shows the number, where it can still help for debugging.

This is an observable change in behavior, but I assume nobody relies on that exact string, so I will not formally consider it a breaking change.