### PR TITLE
Avoid unnecessary traversal in RingBuffer::drop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ use alloc::vec::Vec;
 use core::cell::Cell;
 use core::fmt;
 use core::marker::PhantomData;
-use core::mem::{ManuallyDrop, MaybeUninit};
+use core::mem::{needs_drop, ManuallyDrop, MaybeUninit};
 use core::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 
 #[allow(dead_code, clippy::undocumented_unsafe_blocks)]
@@ -239,14 +239,18 @@ impl<T> RingBuffer<T> {
 impl<T> Drop for RingBuffer<T> {
     /// Drops all non-empty slots.
     fn drop(&mut self) {
-        let mut head = self.head.load(Ordering::Relaxed);
-        let tail = self.tail.load(Ordering::Relaxed);
+        // The wrapping index loop may not be optimized away even when dropping T
+        // does nothing. Skip the traversal entirely for those types.
+        if needs_drop::<T>() {
+            let mut head = self.head.load(Ordering::Relaxed);
+            let tail = self.tail.load(Ordering::Relaxed);
 
-        // Loop over all slots that hold a value and drop them.
-        while head != tail {
-            // SAFETY: All slots between head and tail have been initialized.
-            unsafe { self.slot_ptr(head).drop_in_place() };
-            head = self.increment1(head);
+            // Loop over all slots that hold a value and drop them.
+            while head != tail {
+                // SAFETY: All slots between head and tail have been initialized.
+                unsafe { self.slot_ptr(head).drop_in_place() };
+                head = self.increment1(head);
+            }
         }
 
         // Finally, deallocate the buffer, but don't run any destructors.


### PR DESCRIPTION
Thanks for maintaining this crate! It's been instrumental in my rhythm game, [DeadSync](https://github.com/pnn64/deadsync), and I wanted to contribute a small optimization.

I noticed that `RingBuffer::drop()` walks every unread element even when dropping `T` has no effect. The wrapping index loop can survive optimization, so this adds unnecessary work for types like `u64`.

This PR guards the traversal with `needs_drop::<T>()`. Types requiring cleanup keep the existing destruction behavior, and backing storage is always deallocated.

## Benchmarks

Local results on Windows x86-64 with Rust 1.98, using a full queue of 65,536 `u64` elements:
| Measurement | Before | After | Change |
| --- | ---: | ---: | --- |
| Queue teardown | 43.5 µs | 0.66 µs | ~65× faster |
| Create/fill/destroy lifecycle | 64.2 µs | 23.4 µs | ~2.7× faster |
| CPU cycles per lifecycle | 137,805 | 47,924 | ~65% fewer |
| Allocations at construction | 2 | 2 | Unchanged |
| Allocations during normal operations | 0 | 0 | Unchanged |

Timings were measured with Criterion; CPU cycles were measured separately.

## Testing and linting
- Tests with all features, without default features, and in release mode.
- Additional behavior and allocation checks against both implementations.
- Linux-target Miri under Stacked Borrows and Tree Borrows.
- Formatting, Clippy, documentation checks, and benchmark smoke tests.

The additional tests and benchmarks were used locally; this PR only changes `src/lib.rs`.

🤖 AI disclosure: I used Codex with GPT-6 Astra at xhigh reasoning effort to help identify the optimization and construct the local benchmark. I have reviewed and understand the resulting implementation.