### PR TITLE
Optimize folding over read chunk iterators

### DIFF
--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -1138,8 +1138,9 @@ impl<T> Iterator for ReadChunkIntoIter<'_, T> {
     where
         F: FnMut(B, Self::Item) -> B,
     {
-        // Visit each physical segment separately so the segment selection in
-        // next() can be optimized out of the inner loops.
+        // The default fold() uses one loop over next(). Splitting it by segment
+        // helps the compiler eliminate segment checks and vectorize reductions,
+        // while still obtaining each element through next().
         for _ in self.iterated..self.chunk.first_len {
             init = f(init, self.next().unwrap());
         }
@@ -1151,7 +1152,9 @@ impl<T> Iterator for ReadChunkIntoIter<'_, T> {
 
     #[inline]
     fn count(mut self) -> usize {
-        // A single loop is easier to eliminate when dropping T has no effect.
+        // The default count() calls our split-loop fold(). Keep a single loop
+        // here so the compiler can more easily eliminate traversal when
+        // dropping T has no effect.
         let mut count = 0;
         while self.next().is_some() {
             count += 1;

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -1132,6 +1132,32 @@ impl<T> Iterator for ReadChunkIntoIter<'_, T> {
         let remaining = self.chunk.first_len + self.chunk.second_len - self.iterated;
         (remaining, Some(remaining))
     }
+
+    #[inline]
+    fn fold<B, F>(mut self, mut init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        // Visit each physical segment separately so the segment selection in
+        // next() can be optimized out of the inner loops.
+        for _ in self.iterated..self.chunk.first_len {
+            init = f(init, self.next().unwrap());
+        }
+        for _ in self.iterated..self.chunk.len() {
+            init = f(init, self.next().unwrap());
+        }
+        init
+    }
+
+    #[inline]
+    fn count(mut self) -> usize {
+        // A single loop is easier to eliminate when dropping T has no effect.
+        let mut count = 0;
+        while self.next().is_some() {
+            count += 1;
+        }
+        count
+    }
 }
 
 impl<T> ExactSizeIterator for ReadChunkIntoIter<'_, T> {}


### PR DESCRIPTION
I wanted to follow up with another small optimization. I noticed that folding over `ReadChunkIntoIter` checks which physical segment contains each element. These repeated checks can prevent the compiler from vectorizing reductions like `sum()`.

This PR specializes `fold()` to process each segment separately, reusing the existing `next()` implementation and its progress tracking. It also keeps `count()` on a single loop so the compiler can still eliminate traversal when dropping the element has no effect.

## Benchmarks

Local results on Windows x86-64 with Rust 1.98. Each iteration writes a preallocated slice of `u64` values into an existing queue, then reads and sums the chunk:

| Measurement | Before | After | Change |
| --- | ---: | ---: | --- |
| 64 elements, contiguous | 71.93 ns | 36.35 ns | ~1.98× faster |
| 64 elements, rotating | 84.38 ns | 51.87 ns | ~1.63× faster |
| 4,096 elements, contiguous | 3.911 µs | 2.259 µs | ~1.73× faster |
| 4,096 elements, rotating | 4.090 µs | 3.026 µs | ~1.35× faster |
| CPU cycles, 4,096 contiguous | 8,530 | 4,717 | ~45% fewer |
| CPU cycles, 4,096 rotating | 8,484 | 6,245 | ~26% fewer |
| Allocations at construction | 2 | 2 | Unchanged |
| Allocations during measured operations | 0 | 0 | Unchanged |

Contiguous cases use capacity N; rotating cases use capacity N+1 and cycle through offsets that usually span both segments.

Timings were measured with Criterion; CPU cycles were measured separately. Small `count()` and manual-iteration controls showed mixed timing changes, so these performance gains are specific to the measured write-and-sum workloads.

## Testing and linting

- Tests with all features, without default features, and in release mode.
- Additional behavior and allocation checks against both implementations, including partial iteration, wraparound, destructor counts, panics, zero-sized values, and concurrent use.
- Linux-target Miri under Stacked Borrows and Tree Borrows.
- Formatting, Clippy, documentation checks, and benchmark smoke tests.

The additional tests and benchmarks were used locally; this PR only changes `src/chunks.rs`.

🤖 AI disclosure: I used Codex with GPT-6 Astra at xhigh reasoning effort to help identify the optimization and construct the benchmark. I have reviewed and understand the resulting implementation.